### PR TITLE
Adding support for APNS and GCM dry run mode

### DIFF
--- a/extensions/common.go
+++ b/extensions/common.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -9,7 +10,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// GenerateID generates a fake id with the given size
+// GenerateID generates a an id with the given size
 func GenerateID(size int) string {
 	charset := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	id := make([]byte, size)
@@ -18,4 +19,9 @@ func GenerateID(size int) string {
 		id[i] = charset[n]
 	}
 	return string(id)
+}
+
+// GenerateFakeID generates an id with a FAKE- prefix
+func GenerateFakeID(size int) string {
+	return fmt.Sprintf("FAKE-%s", GenerateID(size))
 }

--- a/extensions/common.go
+++ b/extensions/common.go
@@ -9,7 +9,8 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func IdGenerator(size int) string {
+// GenerateID generates a fake id with the given size
+func GenerateID(size int) string {
 	charset := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	id := make([]byte, size)
 	for i := range id {

--- a/extensions/common.go
+++ b/extensions/common.go
@@ -1,0 +1,20 @@
+package extensions
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func IdGenerator(size int) string {
+	charset := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	id := make([]byte, size)
+	for i := range id {
+		n := rand.Int() % len(charset)
+		id[i] = charset[n]
+	}
+	return string(id)
+}

--- a/extensions/kafka_producer.go
+++ b/extensions/kafka_producer.go
@@ -132,7 +132,7 @@ func (c *KafkaProducer) SendAPNSPush(topic, deviceToken string, payload, message
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.DeviceToken = GenerateID(64)
+			msg.DeviceToken = GenerateFakeID(64)
 		}
 	}
 
@@ -157,7 +157,7 @@ func (c *KafkaProducer) SendGCMPush(topic, deviceToken string, payload, messageM
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.To = GenerateID(152)
+			msg.To = GenerateFakeID(152)
 			msg.DryRun = true
 		}
 	}

--- a/extensions/kafka_producer.go
+++ b/extensions/kafka_producer.go
@@ -132,7 +132,7 @@ func (c *KafkaProducer) SendAPNSPush(topic, deviceToken string, payload, message
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.DeviceToken = IdGenerator(64)
+			msg.DeviceToken = GenerateID(64)
 		}
 	}
 
@@ -157,7 +157,7 @@ func (c *KafkaProducer) SendGCMPush(topic, deviceToken string, payload, messageM
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.To = IdGenerator(152)
+			msg.To = GenerateID(152)
 			msg.DryRun = true
 		}
 	}

--- a/extensions/kafka_producer.go
+++ b/extensions/kafka_producer.go
@@ -130,6 +130,12 @@ func (c *KafkaProducer) SendAPNSPush(topic, deviceToken string, payload, message
 		templateName,
 	)
 
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.DeviceToken = IdGenerator(64)
+		}
+	}
+
 	message, err := msg.ToJSON()
 	if err != nil {
 		return err
@@ -148,6 +154,13 @@ func (c *KafkaProducer) SendGCMPush(topic, deviceToken string, payload, messageM
 		pushExpiry,
 		templateName,
 	)
+
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.To = IdGenerator(152)
+			msg.DryRun = true
+		}
+	}
 
 	message, err := msg.ToJSON()
 	if err != nil {

--- a/testing/fixtures.go
+++ b/testing/fixtures.go
@@ -220,7 +220,7 @@ func CreateTestJob(db interfaces.DB, appID uuid.UUID, templateName string, optio
 
 	filters := getOpt(opts, "filters", map[string]interface{}{"locale": strings.Split(uuid.NewV4().String(), "-")[0]}).(map[string]interface{})
 	context := getOpt(opts, "context", map[string]interface{}{"value": uuid.NewV4().String()}).(map[string]interface{})
-	metadata := getOpt(opts, "filters", map[string]interface{}{"meta": uuid.NewV4().String()}).(map[string]interface{})
+	metadata := getOpt(opts, "metadata", map[string]interface{}{"meta": uuid.NewV4().String()}).(map[string]interface{})
 
 	job := &model.Job{}
 	job.AppID = appID

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -75,7 +75,7 @@ func (f *FakeKafkaProducer) SendAPNSPush(topic, deviceToken string, payload, mes
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.DeviceToken = extensions.IdGenerator(64)
+			msg.DeviceToken = extensions.GenerateID(64)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (f *FakeKafkaProducer) SendGCMPush(topic, deviceToken string, payload, mess
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.To = extensions.IdGenerator(152)
+			msg.To = extensions.GenerateID(152)
 			msg.DryRun = true
 		}
 	}

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -75,7 +75,7 @@ func (f *FakeKafkaProducer) SendAPNSPush(topic, deviceToken string, payload, mes
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.DeviceToken = extensions.GenerateID(64)
+			msg.DeviceToken = extensions.GenerateFakeID(64)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (f *FakeKafkaProducer) SendGCMPush(topic, deviceToken string, payload, mess
 
 	if val, ok := pushMetadata["dryRun"]; ok {
 		if dryRun, _ := val.(bool); dryRun {
-			msg.To = extensions.GenerateID(152)
+			msg.To = extensions.GenerateFakeID(152)
 			msg.DryRun = true
 		}
 	}

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -34,7 +34,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/pg.v5"
+	pg "gopkg.in/pg.v5"
 	"gopkg.in/pg.v5/orm"
 	"gopkg.in/pg.v5/types"
 
@@ -43,6 +43,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/marathon/api"
+	"github.com/topfreegames/marathon/extensions"
 	"github.com/topfreegames/marathon/messages"
 	"github.com/uber-go/zap"
 )
@@ -72,6 +73,12 @@ func (f *FakeKafkaProducer) SendAPNSPush(topic, deviceToken string, payload, mes
 		templateName,
 	)
 
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.DeviceToken = extensions.IdGenerator(64)
+		}
+	}
+
 	message, err := msg.ToJSON()
 	if err != nil {
 		return err
@@ -92,6 +99,13 @@ func (f *FakeKafkaProducer) SendGCMPush(topic, deviceToken string, payload, mess
 		pushExpiry,
 		templateName,
 	)
+
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.To = extensions.IdGenerator(152)
+			msg.DryRun = true
+		}
+	}
 
 	message, err := msg.ToJSON()
 

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -33,7 +33,7 @@ import (
 	redis "gopkg.in/redis.v5"
 
 	workers "github.com/jrallison/go-workers"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/marathon/email"
 	"github.com/topfreegames/marathon/extensions"
@@ -333,6 +333,14 @@ func (batchWorker *ProcessBatchWorker) Process(message *workers.Msg) {
 		// if user.CreatedAt.Unix() > 0 {
 		// 	pushMetadata["tokenCreatedAt"] = user.CreatedAt.Unix()
 		// }
+
+		dryRun := false
+		if val, ok := job.Metadata["dryRun"]; ok {
+			if dryRun, ok = val.(bool); ok {
+				pushMetadata["dryRun"] = dryRun
+			}
+		}
+
 		err = batchWorker.sendToKafka(job.Service, topic, msg, job.Metadata, pushMetadata, user.Token, job.ExpiresAt, templateName)
 		if err != nil {
 			batchErrorCounter = batchErrorCounter + 1

--- a/worker/process_batch_worker_test.go
+++ b/worker/process_batch_worker_test.go
@@ -902,6 +902,7 @@ var _ = Describe("ProcessBatch Worker", func() {
 				Expect(apnsMessage.Metadata[k]).To(BeEquivalentTo(v))
 			}
 			Expect(apnsMessage.DeviceToken).NotTo(BeEquivalentTo(user.Token))
+			Expect(apnsMessage.DeviceToken).To(HavePrefix("FAKE-"))
 		})
 
 		It("should create a dry run message with a fake device token if gcm push", func() {
@@ -960,6 +961,7 @@ var _ = Describe("ProcessBatch Worker", func() {
 				Expect(gcmMessage.Metadata[k]).To(BeEquivalentTo(v))
 			}
 			Expect(gcmMessage.To).NotTo(BeEquivalentTo(user.Token))
+			Expect(gcmMessage.To).To(HavePrefix("FAKE-"))
 			Expect(gcmMessage.DryRun).To(Equal(true))
 		})
 	})


### PR DESCRIPTION
This PR adds support for a dry run mode in Marathon for both APNS and GCM services. 

Since APNS doesn't provide natively a dry run mode, a fake device token is generated to substitute the real one. Even though we could have just enable the DryRun field in the GCMMessage, we also generate a fake registration token for security's sake.

The following changes were introduced:

* A `dryRun` field was added to the `Job`'s metadata in order to indicates that the job should be in test mode
* If present, this field is passed to the `pushMetadata` by the `ProcessBatchWorker`
* The Kafka producers analyses the `pushMetadata` looking for the `dryRun` key and changes the deviceToken for both APNS and GCM message. If it's a `GCMMessage`, the `DryRun` property is set to true
* Two tests were created for the `ProcessBatchWorker` 
* The `FakeKafkaProducer` mock was update to take the pushMetadata's dryRun field into account 
* The test `fixture` was updated to use a job metadata while creating a job
