### PR TITLE
Change Stats Route

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -393,16 +393,17 @@ func (w *Worker) ScheduleJobCompletedJob(jobID string, at int64) (string, error)
 // Start starts the worker
 func (w *Worker) Start() {
 	jobsStatsPort := w.Config.GetInt("workers.statsPort")
-	http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
-		json.NewEncoder(w).Encode(struct {
-			Healthy bool `json:"healthy"`
-		}{
-			Healthy: true,
+	go func() {
+		http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
+			json.NewEncoder(w).Encode(struct {
+				Healthy bool `json:"healthy"`
+			}{
+				Healthy: true,
+			})
 		})
-	})
-	if err := http.ListenAndServe(fmt.Sprint(":", jobsStatsPort), nil); err != nil {
-		panic(err)
-	} else {
-		workers.Run()
-	}
+		if err := http.ListenAndServe(fmt.Sprint(":", jobsStatsPort), nil); err != nil {
+			panic(err)
+		}
+	}()
+	workers.Run()
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -24,6 +24,7 @@ package worker
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -391,6 +392,12 @@ func (w *Worker) ScheduleJobCompletedJob(jobID string, at int64) (string, error)
 // Start starts the worker
 func (w *Worker) Start() {
 	jobsStatsPort := w.Config.GetInt("workers.statsPort")
-	go workers.StatsServer(jobsStatsPort)
-	workers.Run()
+	http.HandleFunc("/_ping", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	if err := http.ListenAndServe(fmt.Sprint(":", jobsStatsPort), nil); err != nil {
+		panic(err)
+	} else {
+		workers.Run()
+	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -393,7 +393,7 @@ func (w *Worker) ScheduleJobCompletedJob(jobID string, at int64) (string, error)
 // Start starts the worker
 func (w *Worker) Start() {
 	jobsStatsPort := w.Config.GetInt("workers.statsPort")
-	http.HandleFunc("/_ping", func(w http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
 		json.NewEncoder(w).Encode(struct {
 			Healthy bool `json:"healthy"`
 		}{

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -23,6 +23,7 @@
 package worker
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -393,7 +394,11 @@ func (w *Worker) ScheduleJobCompletedJob(jobID string, at int64) (string, error)
 func (w *Worker) Start() {
 	jobsStatsPort := w.Config.GetInt("workers.statsPort")
 	http.HandleFunc("/_ping", func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(struct {
+			Healthy bool `json:"healthy"`
+		}{
+			Healthy: true,
+		})
 	})
 	if err := http.ListenAndServe(fmt.Sprint(":", jobsStatsPort), nil); err != nil {
 		panic(err)


### PR DESCRIPTION
After several tests, some pods restarted because of an liveness probe error in `/stats`.

The default Stats server from the `jrallison/go-workers` collect all information present in Redis and show to the user (for example, the pending data to process). In the case of Marathon, this information can be really big, making the retrieved time bigger the liveness probe interval. Has a consequence, the pods ware been killed by the Kubernetes.

This PR changes the stats to a simple function that return true if the pod is ready.
