### PR TITLE
Fix split CSV file in the middle of line

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -40,6 +40,7 @@ workers:
   csvSplitWorker:
     concurrency: 10
     maxRetries: 5
+    csvSizeLimitMB: 10
   createBatches:
     pageProcessingConcurrency: 20
     concurrency: 10

--- a/config/local_compose.yaml
+++ b/config/local_compose.yaml
@@ -40,6 +40,7 @@ workers:
   csvSplitWorker:
     concurrency: 10
     maxRetries: 5
+    csvSizeLimitMB: 10
   createBatches:
     pageProcessingConcurrency: 20
     concurrency: 10

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -46,6 +46,7 @@ workers:
   csvSplitWorker:
     concurrency: 10
     maxRetries: 5
+    csvSizeLimitMB: 10
   createBatches:
     pageProcessingConcurrency: 20
     concurrency: 10

--- a/test_migrations/20201231165810_push.sql
+++ b/test_migrations/20201231165810_push.sql
@@ -37,9 +37,9 @@ INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('5c3033c0-24ad-487a-a80d-68432464c8de', '1237', 'US', 'en', '-0500','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('4223171e-c665-4612-9edd-485f229240bf', '1238', 'BR', 'pt', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('2df5bb01-15d1-4569-bc56-49fa0a33c4c3', '1239', 'US', 'en', '-0300','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('67b872de-8ae4-4763-aef8-7c87a7f928a7', '1244', 'BR', 'pt', '-0500','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('3f8732a1-8642-4f22-8d77-a9688dd6a5ae', '1245', 'BR', 'pt', '-0300','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('21854bbf-ea7e-43e3-8f79-9ab2c121b941', '1246', 'US', 'en', '-0300','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('user_id', '1244', 'BR', 'pt', '-0500','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('idisnotanuuidanditssizecanvaryforeachuser', '1245', 'BR', 'pt', '-0300','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('gamesendsanuseridthatisnotanuuid', '1246', 'US', 'en', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('843a61f8-45b3-44f9-9ab7-8becb2765653', '1247', 'BR', 'pt', '-0500','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('843a61f8-45b3-44f9-9ab7-8becb3365653', '1247', 'AU', 'au', '-0500','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('843a61f8-45b3-44f9-aaaa-8becb3365653', '1247', 'FR', 'fr', '-0800','some adid', 'some_fiu', 'some_vendor_id');
@@ -59,16 +59,17 @@ INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('f57a0010-1318-4997-9a92-dcfb8ca0f24a', '1229', 'CN', 'cn', '-4440','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('6be7b349-6034-4f99-847c-dab3ee4576d0', '1244', 'CN', 'cn', '-4440','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('830a4cbf-c95f-40de-ab20-fef493899944', '1233', 'CN', 'cn', '-4440','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_apns (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('useridisnotanuuid', '1233', 'CN', 'cn', '-4440','some adid', 'some_fiu', 'some_vendor_id');
 
-INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('9e558649-9c23-469d-a11c-59b05000e3d5', '1234', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('useridisnotanuuid', '1234', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('57be9009-e616-42c6-9cfe-505508ede2d0', '1235', 'us', 'EN', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('a8e8d2d5-f178-4d90-9b31-683ad3aae920', '1236', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('5c3033c0-24ad-487a-a80d-68432464c8de', '1237', 'us', 'EN', '-0500','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('4223171e-c665-4612-9edd-485f229240bf', '1238', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('2df5bb01-15d1-4569-bc56-49fa0a33c4c3', '1239', 'us', 'EN', '-0300','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('67b872de-8ae4-4763-aef8-7c87a7f928a7', '1244', 'br', 'PT', '-0500','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('3f8732a1-8642-4f22-8d77-a9688dd6a5ae', '1245', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
-INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('21854bbf-ea7e-43e3-8f79-9ab2c121b941', '1246', 'us', 'EN', '-0300','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('user_id', '1244', 'br', 'PT', '-0500','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('idisnotanuuidanditssizecanvaryforeachuser', '1245', 'br', 'PT', '-0300','some adid', 'some_fiu', 'some_vendor_id');
+INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('gamesendsanuseridthatisnotanuuid', '1246', 'us', 'EN', '-0300','some adid', 'some_fiu', 'some_vendor_id');
 INSERT INTO testapp_gcm (user_id, token, region, locale, tz, adid, fiu, vendor_id) VALUES ('843a61f8-45b3-44f9-9ab7-8becb2765653', '1247', 'br', 'PT', '-0500','some adid', 'some_fiu', 'some_vendor_id');
 
 -- +goose Down

--- a/testing/fixtures.go
+++ b/testing/fixtures.go
@@ -42,7 +42,7 @@ func getOpt(options map[string]interface{}, key string, defaultValue interface{}
 	return val
 }
 
-//CreateTestApp with specified optional values
+// CreateTestApp with specified optional values
 func CreateTestApp(db interfaces.DB, options ...map[string]interface{}) *model.App {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -60,7 +60,7 @@ func CreateTestApp(db interfaces.DB, options ...map[string]interface{}) *model.A
 	return app
 }
 
-//CreateTestApps for n apps
+// CreateTestApps for n apps
 func CreateTestApps(db interfaces.DB, n int, options ...map[string]interface{}) []*model.App {
 	apps := make([]*model.App, n)
 	for i := 0; i < n; i++ {
@@ -71,7 +71,7 @@ func CreateTestApps(db interfaces.DB, n int, options ...map[string]interface{}) 
 	return apps
 }
 
-//CreateTestUser with specified optional values
+// CreateTestUser with specified optional values
 func CreateTestUser(db interfaces.DB, options ...map[string]interface{}) *model.User {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -90,7 +90,7 @@ func CreateTestUser(db interfaces.DB, options ...map[string]interface{}) *model.
 	return user
 }
 
-//CreateTestUsers for n users
+// CreateTestUsers for n users
 func CreateTestUsers(db interfaces.DB, n int, options ...map[string]interface{}) []*model.User {
 	users := make([]*model.User, n)
 	for i := 0; i < n; i++ {
@@ -101,7 +101,7 @@ func CreateTestUsers(db interfaces.DB, n int, options ...map[string]interface{})
 	return users
 }
 
-//GetAppPayload with specified optional values
+// GetAppPayload with specified optional values
 func GetAppPayload(options ...map[string]interface{}) map[string]interface{} {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -119,7 +119,7 @@ func GetAppPayload(options ...map[string]interface{}) map[string]interface{} {
 	return app
 }
 
-//GetUserPayload with specified optional values
+// GetUserPayload with specified optional values
 func GetUserPayload(options ...map[string]interface{}) map[string]interface{} {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -137,7 +137,7 @@ func GetUserPayload(options ...map[string]interface{}) map[string]interface{} {
 	return user
 }
 
-//CreateTestTemplate with specified optional values
+// CreateTestTemplate with specified optional values
 func CreateTestTemplate(db interfaces.DB, appID uuid.UUID, options ...map[string]interface{}) *model.Template {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -161,7 +161,7 @@ func CreateTestTemplate(db interfaces.DB, appID uuid.UUID, options ...map[string
 	return template
 }
 
-//CreateTestTemplates for n apps
+// CreateTestTemplates for n apps
 func CreateTestTemplates(db interfaces.DB, appID uuid.UUID, n int, options ...map[string]interface{}) []*model.Template {
 	templates := make([]*model.Template, n)
 	for i := 0; i < n; i++ {
@@ -172,7 +172,7 @@ func CreateTestTemplates(db interfaces.DB, appID uuid.UUID, n int, options ...ma
 	return templates
 }
 
-//GetTemplatePayload with specified optional values
+// GetTemplatePayload with specified optional values
 func GetTemplatePayload(options ...map[string]interface{}) map[string]interface{} {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -196,7 +196,7 @@ func GetTemplatePayload(options ...map[string]interface{}) map[string]interface{
 	return template
 }
 
-//GetTemplatePayloads with specified optional values
+// GetTemplatePayloads with specified optional values
 func GetTemplatePayloads(amount int, options ...map[string]interface{}) []map[string]interface{} {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -211,7 +211,7 @@ func GetTemplatePayloads(amount int, options ...map[string]interface{}) []map[st
 	return templates
 }
 
-//CreateTestJob with specified optional values
+// CreateTestJob with specified optional values
 func CreateTestJob(db interfaces.DB, appID uuid.UUID, templateName string, options ...map[string]interface{}) *model.Job {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {
@@ -243,7 +243,7 @@ func CreateTestJob(db interfaces.DB, appID uuid.UUID, templateName string, optio
 	return job
 }
 
-//CreateTestJobs for n apps
+// CreateTestJobs for n apps
 func CreateTestJobs(db interfaces.DB, appID uuid.UUID, templateName string, n int, options ...map[string]interface{}) []*model.Job {
 	jobs := make([]*model.Job, n)
 	for i := 0; i < n; i++ {
@@ -254,7 +254,7 @@ func CreateTestJobs(db interfaces.DB, appID uuid.UUID, templateName string, n in
 	return jobs
 }
 
-//GetJobPayload with specified optional values
+// GetJobPayload with specified optional values
 func GetJobPayload(options ...map[string]interface{}) map[string]interface{} {
 	opts := map[string]interface{}{}
 	if len(options) == 1 {

--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -59,7 +59,8 @@ func NewCreateBatchesWorker(workers *Worker) *CreateBatchesWorker {
 }
 
 // ReadFromCSV reads CSV from S3 and return correspondent array of strings
-func (b *CreateBatchesWorker) ReadFromCSV(buffer *[]byte, job *model.Job) []string {
+func (b *CreateBatchesWorker) ReadFromCSV(buffer *[]byte, msg *BatchPart) []string {
+	job := &msg.Job
 	for i, b := range *buffer {
 		if b == 0x0D {
 			(*buffer)[i] = 0x0A
@@ -71,7 +72,7 @@ func (b *CreateBatchesWorker) ReadFromCSV(buffer *[]byte, job *model.Job) []stri
 	b.checkErr(job, err)
 	res := []string{}
 	for i, line := range lines {
-		if i == 0 {
+		if i == 0 && msg.Part == 0 {
 			continue
 		}
 		res = append(res, line[0])
@@ -184,7 +185,7 @@ func (b *CreateBatchesWorker) processIDs(userIds []string, msg *BatchPart) {
 // get the list of ids and send to redis the splited ids
 func (b *CreateBatchesWorker) getIDs(buffer *bytes.Buffer, msg *BatchPart) []string {
 	bBystes := buffer.Bytes()
-	lines := b.ReadFromCSV(&bBystes, &msg.Job)
+	lines := b.ReadFromCSV(&bBystes, msg)
 	totalLines := len(lines)
 	start := 0
 	end := totalLines

--- a/worker/create_batches_worker_test.go
+++ b/worker/create_batches_worker_test.go
@@ -733,7 +733,7 @@ d6333e62-2778-463c-b7d6-4d99aab04fb8
 			err = w.MarathonDB.Model(job).Where("id = ?", j.ID).Select()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(job.TotalTokens).To(BeEquivalentTo(4))
-			Expect(job.TotalUsers).To(BeEquivalentTo(2))
+			Expect(job.TotalUsers).To(BeEquivalentTo(4))
 		})
 
 		It("should increment job totalTokens when previous totalTokens", func() {

--- a/worker/create_batches_worker_test.go
+++ b/worker/create_batches_worker_test.go
@@ -57,9 +57,9 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 5c3033c0-24ad-487a-a80d-68432464c8de
 4223171e-c665-4612-9edd-485f229240bf
 2df5bb01-15d1-4569-bc56-49fa0a33c4c3
-67b872de-8ae4-4763-aef8-7c87a7f928a7
-3f8732a1-8642-4f22-8d77-a9688dd6a5ae
-21854bbf-ea7e-43e3-8f79-9ab2c121b941
+user_id
+idisnotanuuidanditssizecanvaryforeachuser
+gamesendsanuseridthatisnotanuuid
 843a61f8-45b3-44f9-9ab7-8becb2765653`)
 		fakeData2 := []byte(`userids`)
 		fakeData3 := []byte(`userids
@@ -91,6 +91,13 @@ d6333e62-2778-463c-b7d6-4d99aab04fb8
 57be9009-e616-42c6-9cfe-505508ede2d0
 a8e8d2d5-f178-4d90-9b31-683ad3aae920
 5c3033c0-24ad-487a-a80d-68432464c8de`)
+		// Ids are not uuid
+		fakeData9 := []byte(`userIds
+useridisnotanuuid
+gamesendsanuseridthatisnotanuuid
+idisnotanuuidanditssizecanvaryforeachuser
+user_id
+`)
 
 		fakeS3.PutObject("test/jobs/obj1.csv", &fakeData1)
 		fakeS3.PutObject("test/jobs/obj2.csv", &fakeData2)
@@ -100,6 +107,7 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 		fakeS3.PutObject("test/jobs/obj6.csv", &fakeData6)
 		fakeS3.PutObject("test/jobs/obj7.csv", &fakeData7)
 		fakeS3.PutObject("test/jobs/obj8.csv", &fakeData8)
+		fakeS3.PutObject("test/jobs/obj9.csv", &fakeData9)
 		app = CreateTestApp(w.MarathonDB)
 		defaults := map[string]interface{}{
 			"user_name":   "Someone",
@@ -873,7 +881,7 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 			// two processed batches and 1 batch from split ids process
 			Expect(res).To(BeEquivalentTo(3))
 
-			users := 0
+			userIds := map[string]string{}
 			for i := 0; i < int(res); i++ {
 				job1, err := w.RedisClient.LPop("queue:process_batch_worker").Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -882,11 +890,20 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 				Expect(err).NotTo(HaveOccurred())
 				Expect(j1["queue"].(string)).To(Equal("process_batch_worker"))
 				wMessage1, err := worker.ParseProcessBatchWorkerMessageArray(j1["args"].([]interface{}))
-				users += len(wMessage1.Users)
+
+				for _, user := range wMessage1.Users {
+					userIds[user.UserID] = user.UserID
+				}
+
 				Expect(err).NotTo(HaveOccurred())
 			}
+			Expect(len(userIds)).To(BeEquivalentTo(4))
 
-			Expect(users).To(BeEquivalentTo(4))
+			Expect(userIds["9e558649-9c23-469d-a11c-59b05813e3d5"]).To(BeEquivalentTo("9e558649-9c23-469d-a11c-59b05813e3d5"))
+			Expect(userIds["57be9009-e616-42c6-9cfe-505508ede2d0"]).To(BeEquivalentTo("57be9009-e616-42c6-9cfe-505508ede2d0"))
+			Expect(userIds["a8e8d2d5-f178-4d90-9b31-683ad3aae920"]).To(BeEquivalentTo("a8e8d2d5-f178-4d90-9b31-683ad3aae920"))
+			Expect(userIds["5c3033c0-24ad-487a-a80d-68432464c8de"]).To(BeEquivalentTo("5c3033c0-24ad-487a-a80d-68432464c8de"))
+
 		})
 	})
 
@@ -895,7 +912,7 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 		j := CreateTestJob(w.MarathonDB, a.ID, template.Name, map[string]interface{}{
 			"context": context,
 			"filters": map[string]interface{}{},
-			"csvPath": "test/jobs/obj8.csv",
+			"csvPath": "test/jobs/obj9.csv",
 		})
 
 		_, err := w.CreateCSVSplitJob(j)
@@ -907,7 +924,7 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 		Expect(err).NotTo(HaveOccurred())
 		// it's the size of the header + part of the first id
 		sizeLimit := 40
-		totalParts := 4
+		totalParts := 3
 		Expect(err).NotTo(HaveOccurred())
 		createCSVSplitWorker.Workers.Config.Set("workers.csvSplitWorker.csvSizeLimitMB", float64(sizeLimit)/1024/1024)
 		Expect(func() { createCSVSplitWorker.Process(msg) }).ShouldNot(Panic())
@@ -922,10 +939,10 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 
 		res, err := w.RedisClient.LLen("queue:process_batch_worker").Result()
 		Expect(err).NotTo(HaveOccurred())
-		// The process batch with first id and other process batch resulted from split ids
-		Expect(res).To(BeEquivalentTo(2))
+		// two processed batches and 1 batch from split ids process
+		Expect(res).To(BeEquivalentTo(3))
 
-		users := 0
+		userIds := map[string]string{}
 		for i := 0; i < int(res); i++ {
 			job1, err := w.RedisClient.LPop("queue:process_batch_worker").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -934,11 +951,16 @@ a8e8d2d5-f178-4d90-9b31-683ad3aae920
 			Expect(err).NotTo(HaveOccurred())
 			Expect(j1["queue"].(string)).To(Equal("process_batch_worker"))
 			wMessage1, err := worker.ParseProcessBatchWorkerMessageArray(j1["args"].([]interface{}))
-			users += len(wMessage1.Users)
+			for _, user := range wMessage1.Users {
+				userIds[user.UserID] = user.UserID
+			}
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		Expect(users).To(BeEquivalentTo(4))
+		Expect(userIds["user_id"]).To(BeEquivalentTo("user_id"))
+		Expect(userIds["useridisnotanuuid"]).To(BeEquivalentTo("useridisnotanuuid"))
+		Expect(userIds["gamesendsanuseridthatisnotanuuid"]).To(BeEquivalentTo("gamesendsanuseridthatisnotanuuid"))
+		Expect(userIds["idisnotanuuidanditssizecanvaryforeachuser"]).To(BeEquivalentTo("idisnotanuuidanditssizecanvaryforeachuser"))
 	})
 
 	// Describe("Read CSV from S3", func() {

--- a/worker/csv_split.go
+++ b/worker/csv_split.go
@@ -93,12 +93,12 @@ func (b *CSVSplitWorker) Process(message *workers.Msg) {
 	b.checkErr(job, err)
 
 	start := 0
-	totalParts := int(math.Ceil(float64(totalSize) / float64(csvSizeLimit)))
+	totalParts := int(math.Ceil(float64(totalSize) / csvSizeLimit))
 
 	for i := 0; i < totalParts; i++ {
 		size := totalSize - start
-		if size > csvSizeLimit {
-			size = csvSizeLimit
+		if size > int(math.Ceil(csvSizeLimit)) {
+			size = int(math.Ceil(csvSizeLimit))
 		}
 		_, err := b.Workers.CreateBatchesJob(&BatchPart{
 			Start:      start,
@@ -122,9 +122,9 @@ func (b *CSVSplitWorker) checkErr(job *model.Job, err error) {
 	}
 }
 
-func (b *CSVSplitWorker) getCSVSizeLimitBytes() int {
+func (b *CSVSplitWorker) getCSVSizeLimitBytes() float64 {
 	b.Workers.Config.SetDefault("workers.csvSplitWorker.csvSizeLimitMB", 10)
-	csvSizeLimitMB := b.Workers.Config.GetInt("workers.csvSplitWorker.csvSizeLimitMB")
+	csvSizeLimitMB := b.Workers.Config.GetFloat64("workers.csvSplitWorker.csvSizeLimitMB")
 
 	return csvSizeLimitMB * 1024 * 1024
 }


### PR DESCRIPTION
This PR is adding a fix to how the workers split CSV files:

- To do this and make it testable the CSV size limit now is configurable by an environment var. Even with the comment warning about memory overflow in case of an increase in the CSV size limit, having this value configurable is a good approach to set up the workers more efficiently without changing the code and make the tests easier.
- Remove the header only on the first part of the file, the old behavior was to remove the first line of each part of the file.
- No more stopping the job when the CSV file part doesn't have IDs because the ids are incomplete and were moved to the split id process
- The incomplete IDs are stored in Redis to be processed by another batch process
