### PR TITLE
Fix create_batches_worker test

### DIFF
--- a/worker/create_batches_worker_test.go
+++ b/worker/create_batches_worker_test.go
@@ -733,7 +733,7 @@ d6333e62-2778-463c-b7d6-4d99aab04fb8
 			err = w.MarathonDB.Model(job).Where("id = ?", j.ID).Select()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(job.TotalTokens).To(BeEquivalentTo(4))
-			Expect(job.TotalUsers).To(BeEquivalentTo(2))
+			Expect(job.TotalUsers).To(BeEquivalentTo(4))
 		})
 
 		It("should increment job totalTokens when previous totalTokens", func() {


### PR DESCRIPTION
The test data set actually return four users in the query and the test was expecting two.