### PR TITLE
Add success and error metrics to every worker

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -60,3 +60,8 @@ Also, it reads the Redis and creates the control group CSV.
 ### Resume Job Worker
 
 This worker handles jobs that are paused or in circuit break state. It removes a batch from the paused job list and calls the process batch worker for each one of them until are has no more paused batches.
+
+### Metrics
+
+Each one of the workers has metrics indicating the start (e.g. `starting_create_batches_worker`), the completion (e.g. `completed_create_batches_worker`) and possible execution errors (e.g. `error_create_batches_worker`).
+The error metrics are only generated for internal errors or input validation errors, for instance when no valid IDs are present in the CSV file. In every other case, the workers will generate the completed metric.

--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -259,6 +259,7 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 
 	if msg.Job.Status == stoppedJobStatus {
 		l.Info("stopped job")
+		b.Workers.Statsd.Incr(CreateBatchesWorkerCompleted, msg.Job.Labels(), 1)
 		return
 	}
 	l.Info("starting")

--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -252,8 +252,11 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 		zap.Int("totalParts", msg.TotalParts),
 	)
 
+	b.Workers.Statsd.Incr(createBatchesWorkerStart, msg.Job.Labels(), 1)
+
 	err = b.Workers.MarathonDB.Model(&msg.Job).Column("job.status", "App").Where("job.id = ?", msg.Job.ID).Select()
-	checkErr(l, err)
+	b.checkErr(&msg.Job, err)
+
 	if msg.Job.Status == stoppedJobStatus {
 		l.Info("stopped job")
 		return
@@ -269,7 +272,7 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 	_, buffer, err := b.Workers.S3Client.DownloadChunk(int64(msg.Start), int64(msg.Size), msg.Job.CSVPath)
 	labels := msg.Job.Labels()
 	labels = append(labels, fmt.Sprintf("error:%t", err != nil))
-	b.Workers.Statsd.Timing("get_csv_from_s3", time.Now().Sub(start), labels, 1)
+	b.Workers.Statsd.Timing(getCsvFromS3Timing, time.Now().Sub(start), labels, 1)
 	b.checkErr(&msg.Job, err)
 
 	ids := b.getIDs(buffer, &msg)
@@ -292,8 +295,10 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 		if msg.Job.TotalUsers == 0 {
 			b.updateCompletedAt(time.Now().UnixNano(), &msg.Job)
 			msg.Job.TagError(b.Workers.MarathonDB, nameCreateBatches, "the job has finished without finding any valid user ids")
+			b.Workers.Statsd.Incr(createBatchesWorkerError, msg.Job.Labels(), 1)
 		} else {
 			msg.Job.TagSuccess(b.Workers.MarathonDB, nameCreateBatches, "finished")
+			b.Workers.Statsd.Incr(createBatchesWorkerCompleted, msg.Job.Labels(), 1)
 		}
 
 		// TODO: schedule a job to run after send all messages. This job will check
@@ -310,6 +315,8 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 func (b *CreateBatchesWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameCreateBatches, err.Error())
+		b.Workers.Statsd.Incr(createBatchesWorkerError, job.Labels(), 1)
+
 		checkErr(b.Logger, err)
 	}
 }

--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -252,7 +252,7 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 		zap.Int("totalParts", msg.TotalParts),
 	)
 
-	b.Workers.Statsd.Incr(createBatchesWorkerStart, msg.Job.Labels(), 1)
+	b.Workers.Statsd.Incr(CreateBatchesWorkerStart, msg.Job.Labels(), 1)
 
 	err = b.Workers.MarathonDB.Model(&msg.Job).Column("job.status", "App").Where("job.id = ?", msg.Job.ID).Select()
 	b.checkErr(&msg.Job, err)
@@ -272,7 +272,7 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 	_, buffer, err := b.Workers.S3Client.DownloadChunk(int64(msg.Start), int64(msg.Size), msg.Job.CSVPath)
 	labels := msg.Job.Labels()
 	labels = append(labels, fmt.Sprintf("error:%t", err != nil))
-	b.Workers.Statsd.Timing(getCsvFromS3Timing, time.Now().Sub(start), labels, 1)
+	b.Workers.Statsd.Timing(GetCsvFromS3Timing, time.Now().Sub(start), labels, 1)
 	b.checkErr(&msg.Job, err)
 
 	ids := b.getIDs(buffer, &msg)
@@ -295,10 +295,10 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 		if msg.Job.TotalUsers == 0 {
 			b.updateCompletedAt(time.Now().UnixNano(), &msg.Job)
 			msg.Job.TagError(b.Workers.MarathonDB, nameCreateBatches, "the job has finished without finding any valid user ids")
-			b.Workers.Statsd.Incr(createBatchesWorkerError, msg.Job.Labels(), 1)
+			b.Workers.Statsd.Incr(CreateBatchesWorkerError, msg.Job.Labels(), 1)
 		} else {
 			msg.Job.TagSuccess(b.Workers.MarathonDB, nameCreateBatches, "finished")
-			b.Workers.Statsd.Incr(createBatchesWorkerCompleted, msg.Job.Labels(), 1)
+			b.Workers.Statsd.Incr(CreateBatchesWorkerCompleted, msg.Job.Labels(), 1)
 		}
 
 		// TODO: schedule a job to run after send all messages. This job will check
@@ -315,7 +315,7 @@ func (b *CreateBatchesWorker) Process(message *workers.Msg) {
 func (b *CreateBatchesWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameCreateBatches, err.Error())
-		b.Workers.Statsd.Incr(createBatchesWorkerError, job.Labels(), 1)
+		b.Workers.Statsd.Incr(CreateBatchesWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}

--- a/worker/csv_split.go
+++ b/worker/csv_split.go
@@ -86,7 +86,7 @@ func (b *CSVSplitWorker) Process(message *workers.Msg) {
 	job, err := b.Workers.GetJob(id)
 	checkErr(l, err)
 	job.TagRunning(b.Workers.MarathonDB, nameSCVSplit, "starting")
-	b.Workers.Statsd.Incr(csvSplitWorkerStart, job.Labels(), 1)
+	b.Workers.Statsd.Incr(CsvSplitWorkerStart, job.Labels(), 1)
 
 	if job.Status == stoppedJobStatus {
 		l.Info("stopped job")
@@ -119,14 +119,14 @@ func (b *CSVSplitWorker) Process(message *workers.Msg) {
 	}
 
 	job.TagSuccess(b.Workers.MarathonDB, nameSCVSplit, "finished")
-	b.Workers.Statsd.Incr(csvSplitWorkerCompleted, job.Labels(), 1)
+	b.Workers.Statsd.Incr(CsvSplitWorkerCompleted, job.Labels(), 1)
 	l.Info("finished")
 }
 
 func (b *CSVSplitWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameSCVSplit, err.Error())
-		b.Workers.Statsd.Incr(csvSplitWorkerError, job.Labels(), 1)
+		b.Workers.Statsd.Incr(CsvSplitWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}

--- a/worker/csv_split.go
+++ b/worker/csv_split.go
@@ -90,6 +90,7 @@ func (b *CSVSplitWorker) Process(message *workers.Msg) {
 
 	if job.Status == stoppedJobStatus {
 		l.Info("stopped job")
+		b.Workers.Statsd.Incr(CsvSplitWorkerCompleted, job.Labels(), 1)
 		return
 	}
 

--- a/worker/direct_worker.go
+++ b/worker/direct_worker.go
@@ -130,18 +130,22 @@ func (b *DirectWorker) Process(message *workers.Msg) {
 
 	if job.ExpiresAt > 0 && job.ExpiresAt < time.Now().UnixNano() {
 		log.I(l, "expired")
+		b.Workers.Statsd.Incr(DirectWorkerCompleted, job.Labels(), 1)
 		return
 	}
 
 	switch job.Status {
 	case "circuitbreak":
 		log.I(l, "circuit break")
+		b.Workers.Statsd.Incr(DirectWorkerCompleted, job.Labels(), 1)
 		return
 	case "paused":
 		log.I(l, "paused")
+		b.Workers.Statsd.Incr(DirectWorkerCompleted, job.Labels(), 1)
 		return
 	case "stopped":
 		log.I(l, "stopped")
+		b.Workers.Statsd.Incr(DirectWorkerCompleted, job.Labels(), 1)
 		return
 	default:
 		log.D(l, "valid")
@@ -163,7 +167,7 @@ func (b *DirectWorker) Process(message *workers.Msg) {
 		l.Error("Error fetching users", zap.Error(err))
 	}
 
-	b.Workers.Statsd.Timing("get_from_pg", time.Now().Sub(start), job.Labels(), 1)
+	b.Workers.Statsd.Timing(GetUsersFromDbTiming, time.Now().Sub(start), job.Labels(), 1)
 
 	successfulUsers := len(users)
 

--- a/worker/direct_worker.go
+++ b/worker/direct_worker.go
@@ -126,7 +126,7 @@ func (b *DirectWorker) Process(message *workers.Msg) {
 
 	job, err := b.Workers.GetJob(msg.JobUUID)
 	checkErr(l, err)
-	b.Workers.Statsd.Incr(directWorkerStart, job.Labels(), 1)
+	b.Workers.Statsd.Incr(DirectWorkerStart, job.Labels(), 1)
 
 	if job.ExpiresAt > 0 && job.ExpiresAt < time.Now().UnixNano() {
 		log.I(l, "expired")
@@ -266,14 +266,14 @@ func (b *DirectWorker) Process(message *workers.Msg) {
 		_, err = b.Workers.ScheduleJobCompletedJob(job.ID.String(), at)
 	}
 
-	b.Workers.Statsd.Incr(directWorkerCompleted, job.Labels(), 1)
+	b.Workers.Statsd.Incr(DirectWorkerCompleted, job.Labels(), 1)
 	l.Info("finished")
 }
 
 func (b *DirectWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameDirectWorker, err.Error())
-		b.Workers.Statsd.Incr(directWorkerError, job.Labels(), 1)
+		b.Workers.Statsd.Incr(DirectWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}

--- a/worker/job_completed_worker.go
+++ b/worker/job_completed_worker.go
@@ -100,7 +100,7 @@ func (b *JobCompletedWorker) Process(message *workers.Msg) {
 	job, err := b.Workers.GetJob(id)
 	checkErr(l, err)
 
-	b.Workers.Statsd.Incr(jobCompletedWorkerStart, job.Labels(), 1)
+	b.Workers.Statsd.Incr(JobCompletedWorkerStart, job.Labels(), 1)
 
 	job.TagRunning(b.Workers.MarathonDB, nameJobCompleted, "starting")
 
@@ -113,7 +113,7 @@ func (b *JobCompletedWorker) Process(message *workers.Msg) {
 	b.flushControlGroup(job)
 
 	job.TagSuccess(b.Workers.MarathonDB, nameJobCompleted, "finished")
-	b.Workers.Statsd.Incr(jobCompletedWorkerCompleted, job.Labels(), 1)
+	b.Workers.Statsd.Incr(JobCompletedWorkerCompleted, job.Labels(), 1)
 
 	log.I(l, "finished")
 }
@@ -121,7 +121,7 @@ func (b *JobCompletedWorker) Process(message *workers.Msg) {
 func (b *JobCompletedWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameJobCompleted, err.Error())
-		b.Workers.Statsd.Incr(jobCompletedWorkerError, job.Labels(), 1)
+		b.Workers.Statsd.Incr(JobCompletedWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}

--- a/worker/metrics.go
+++ b/worker/metrics.go
@@ -1,29 +1,29 @@
 package worker
 
 const (
-	createBatchesWorkerStart     = "starting_create_batches_worker"
-	createBatchesWorkerCompleted = "completed_create_batches_worker"
-	createBatchesWorkerError     = "error_create_batches_worker"
+	CreateBatchesWorkerStart     = "starting_create_batches_worker"
+	CreateBatchesWorkerCompleted = "completed_create_batches_worker"
+	CreateBatchesWorkerError     = "error_create_batches_worker"
 
-	csvSplitWorkerStart     = "starting_csv_split_worker"
-	csvSplitWorkerCompleted = "completed_csv_split_worker"
-	csvSplitWorkerError     = "error_csv_split_worker"
+	CsvSplitWorkerStart     = "starting_csv_split_worker"
+	CsvSplitWorkerCompleted = "completed_csv_split_worker"
+	CsvSplitWorkerError     = "error_csv_split_worker"
 
-	directWorkerStart     = "starting_direct_part"
-	directWorkerCompleted = "completed_direct_worker"
-	directWorkerError     = "error_direct_worker"
+	DirectWorkerStart     = "starting_direct_part"
+	DirectWorkerCompleted = "completed_direct_worker"
+	DirectWorkerError     = "error_direct_worker"
 
-	jobCompletedWorkerStart     = "starting_job_completed_worker"
-	jobCompletedWorkerCompleted = "completed_job_completed_worker"
-	jobCompletedWorkerError     = "error_job_completed_worker"
+	JobCompletedWorkerStart     = "starting_job_completed_worker"
+	JobCompletedWorkerCompleted = "completed_job_completed_worker"
+	JobCompletedWorkerError     = "error_job_completed_worker"
 
-	processBatchWorkerStart     = "starting_process_batch_worker"
-	processBatchWorkerCompleted = "completed_process_batch_worker"
-	processBatchWorkerError     = "error_process_batch_worker"
+	ProcessBatchWorkerStart     = "starting_process_batch_worker"
+	ProcessBatchWorkerCompleted = "completed_process_batch_worker"
+	ProcessBatchWorkerError     = "error_process_batch_worker"
 
-	resumeJobWorkerStart     = "starting_resume_job_worker"
-	resumeJobWorkerCompleted = "completed_resume_job_worker"
-	resumeJobWorkerError     = "error_resume_job_worker"
+	ResumeJobWorkerStart     = "starting_resume_job_worker"
+	ResumeJobWorkerCompleted = "completed_resume_job_worker"
+	ResumeJobWorkerError     = "error_resume_job_worker"
 
-	getCsvFromS3Timing = "get_csv_from_s3"
+	GetCsvFromS3Timing = "get_csv_from_s3"
 )

--- a/worker/metrics.go
+++ b/worker/metrics.go
@@ -25,5 +25,6 @@ const (
 	ResumeJobWorkerCompleted = "completed_resume_job_worker"
 	ResumeJobWorkerError     = "error_resume_job_worker"
 
-	GetCsvFromS3Timing = "get_csv_from_s3"
+	GetCsvFromS3Timing   = "get_csv_from_s3"
+	GetUsersFromDbTiming = "get_from_pg"
 )

--- a/worker/metrics.go
+++ b/worker/metrics.go
@@ -1,0 +1,29 @@
+package worker
+
+const (
+	createBatchesWorkerStart     = "starting_create_batches_worker"
+	createBatchesWorkerCompleted = "completed_create_batches_worker"
+	createBatchesWorkerError     = "error_create_batches_worker"
+
+	csvSplitWorkerStart     = "starting_csv_split_worker"
+	csvSplitWorkerCompleted = "completed_csv_split_worker"
+	csvSplitWorkerError     = "error_csv_split_worker"
+
+	directWorkerStart     = "starting_direct_part"
+	directWorkerCompleted = "completed_direct_worker"
+	directWorkerError     = "error_direct_worker"
+
+	jobCompletedWorkerStart     = "starting_job_completed_worker"
+	jobCompletedWorkerCompleted = "completed_job_completed_worker"
+	jobCompletedWorkerError     = "error_job_completed_worker"
+
+	processBatchWorkerStart     = "starting_process_batch_worker"
+	processBatchWorkerCompleted = "completed_process_batch_worker"
+	processBatchWorkerError     = "error_process_batch_worker"
+
+	resumeJobWorkerStart     = "starting_resume_job_worker"
+	resumeJobWorkerCompleted = "completed_resume_job_worker"
+	resumeJobWorkerError     = "error_resume_job_worker"
+
+	getCsvFromS3Timing = "get_csv_from_s3"
+)

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -55,20 +55,20 @@ func NewProcessBatchWorker(workers *Worker) *ProcessBatchWorker {
 	return b
 }
 
-func (b *ProcessBatchWorker) incrFailedBatches(jobID uuid.UUID, totalBatches int, appName string) {
-	failedJobs, err := b.Workers.RedisClient.Incr(fmt.Sprintf("%s-failedbatches", jobID.String())).Result()
-	checkErr(b.Logger, err)
-	ttl, err := b.Workers.RedisClient.TTL(fmt.Sprintf("%s-failedbatches", jobID.String())).Result()
-	checkErr(b.Logger, err)
+func (b *ProcessBatchWorker) incrFailedBatches(j *model.Job, appName string) {
+	failedJobs, err := b.Workers.RedisClient.Incr(fmt.Sprintf("%s-failedbatches", j.ID.String())).Result()
+	b.checkErr(j, err)
+	ttl, err := b.Workers.RedisClient.TTL(fmt.Sprintf("%s-failedbatches", j.ID.String())).Result()
+	b.checkErr(j, err)
 	if ttl < 0 {
-		b.Workers.RedisClient.Expire(fmt.Sprintf("%s-failedbatches", jobID.String()), 7*24*time.Hour)
+		b.Workers.RedisClient.Expire(fmt.Sprintf("%s-failedbatches", j.ID.String()), 7*24*time.Hour)
 	}
-	if float64(failedJobs)/float64(totalBatches) >= b.Workers.Config.GetFloat64("workers.processBatch.maxBatchFailure") {
+	if float64(failedJobs)/float64(j.TotalBatches) >= b.Workers.Config.GetFloat64("workers.processBatch.maxBatchFailure") {
 		job := model.Job{}
-		_, err := b.Workers.MarathonDB.Model(&job).Set("status = 'circuitbreak'").Where("id = ?", jobID).Returning("*").Update()
-		checkErr(b.Logger, err)
-		changedStatus, err := b.Workers.RedisClient.SetNX(fmt.Sprintf("%s-circuitbreak", jobID.String()), 1, 1*time.Minute).Result()
-		checkErr(b.Logger, err)
+		_, err := b.Workers.MarathonDB.Model(&job).Set("status = 'circuitbreak'").Where("id = ?", j.ID).Returning("*").Update()
+		b.checkErr(j, err)
+		changedStatus, err := b.Workers.RedisClient.SetNX(fmt.Sprintf("%s-circuitbreak", j.ID.String()), 1, 1*time.Minute).Result()
+		b.checkErr(j, err)
 		if changedStatus && b.Workers.SendgridClient != nil {
 			var expireAt int64
 			if ttl > 0 {
@@ -136,13 +136,13 @@ func (b *ProcessBatchWorker) updateJobBatchesInfo(jobID uuid.UUID) error {
 	return err
 }
 
-func (b *ProcessBatchWorker) moveJobToPausedQueue(jobID uuid.UUID, message *workers.Msg) {
-	_, err := b.Workers.RedisClient.RPush(fmt.Sprintf("%s-pausedjobs", jobID.String()), message.ToJson()).Result()
-	checkErr(b.Logger, err)
-	ttl, err := b.Workers.RedisClient.TTL(fmt.Sprintf("%s-pausedjobs", jobID.String())).Result()
-	checkErr(b.Logger, err)
+func (b *ProcessBatchWorker) moveJobToPausedQueue(job *model.Job, message *workers.Msg) {
+	_, err := b.Workers.RedisClient.RPush(fmt.Sprintf("%s-pausedjobs", job.ID.String()), message.ToJson()).Result()
+	b.checkErr(job, err)
+	ttl, err := b.Workers.RedisClient.TTL(fmt.Sprintf("%s-pausedjobs", job.ID.String())).Result()
+	b.checkErr(job, err)
 	if ttl < 0 {
-		b.Workers.RedisClient.Expire(fmt.Sprintf("%s-pausedjobs", jobID.String()), 7*24*time.Hour)
+		b.Workers.RedisClient.Expire(fmt.Sprintf("%s-pausedjobs", job.ID.String()), 7*24*time.Hour)
 	}
 }
 
@@ -178,7 +178,7 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 	b.checkErrWithReEnqueue(parsed, l, err)
 
 	log.D(l, "Retrieved job successfully.")
-	b.Workers.Statsd.Incr("starting_process_batch_worker", job.Labels(), 1)
+	b.Workers.Statsd.Incr(processBatchWorkerStart, job.Labels(), 1)
 
 	if job.ExpiresAt > 0 && job.ExpiresAt < time.Now().UnixNano() {
 		log.I(l, "expired")
@@ -188,11 +188,11 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 	switch job.Status {
 	case "circuitbreak":
 		log.I(l, "circuit break")
-		b.moveJobToPausedQueue(job.ID, message)
+		b.moveJobToPausedQueue(job, message)
 		return
 	case "paused":
 		log.I(l, "paused")
-		b.moveJobToPausedQueue(job.ID, message)
+		b.moveJobToPausedQueue(job, message)
 		return
 	case "stopped":
 		log.I(l, "stopped")
@@ -203,7 +203,7 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 
 	templatesByNameAndLocale, err := job.GetJobTemplatesByNameAndLocale(b.Workers.MarathonDB)
 	if err != nil {
-		b.incrFailedBatches(job.ID, job.TotalBatches, parsed.AppName)
+		b.incrFailedBatches(job, parsed.AppName)
 	}
 	b.checkErrWithReEnqueue(parsed, l, err)
 	log.D(l, "Retrieved templatesByNameAndLocale successfully.", func(cm log.CM) {
@@ -233,21 +233,21 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 		} else if val, ok := templatesByLocale["en"]; ok {
 			template = val
 		} else {
-			b.incrFailedBatches(job.ID, job.TotalBatches, parsed.AppName)
-			checkErr(l, fmt.Errorf("there is no template for the given locale or 'en'"))
+			b.incrFailedBatches(job, parsed.AppName)
+			b.checkErr(job, fmt.Errorf("there is no template for the given locale or 'en'"))
 		}
 
 		msgStr, msgErr := BuildMessageFromTemplate(template, job.Context)
 		if msgErr != nil {
-			b.incrFailedBatches(job.ID, job.TotalBatches, parsed.AppName)
+			b.incrFailedBatches(job, parsed.AppName)
 		}
-		checkErr(l, msgErr)
+		b.checkErr(job, msgErr)
 		var msg map[string]interface{}
 		err = json.Unmarshal([]byte(msgStr), &msg)
 		if err != nil {
-			b.incrFailedBatches(job.ID, job.TotalBatches, parsed.AppName)
+			b.incrFailedBatches(job, parsed.AppName)
 		}
-		checkErr(l, err)
+		b.checkErr(job, err)
 		pushMetadata := map[string]interface{}{
 			"userId":       user.UserID,
 			"pushTime":     time.Now().Unix(),
@@ -282,14 +282,25 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 	}
 	log.D(l, "Sent push to pusher for batch users.")
 	err = b.updateJobBatchesInfo(parsed.JobID)
-	checkErr(l, err)
+	b.checkErr(job, err)
 	log.D(l, "Updated job batches info successfully.")
 	err = b.updateJobUsersInfo(parsed.JobID, len(parsed.Users)-batchErrorCounter)
-	checkErr(l, err)
+	b.checkErr(job, err)
 	log.D(l, "Updated job users info successfully.")
 	if float64(batchErrorCounter)/float64(len(parsed.Users)) > b.Workers.Config.GetFloat64("workers.processBatch.maxUserFailureInBatch") {
-		b.incrFailedBatches(job.ID, job.TotalBatches, parsed.AppName)
-		checkErr(l, fmt.Errorf("failed to send message to several users, considering batch as failed"))
+		b.incrFailedBatches(job, parsed.AppName)
+		b.checkErr(job, fmt.Errorf("failed to send message to several users, considering batch as failed"))
 	}
+
+	b.Workers.Statsd.Incr(processBatchWorkerCompleted, job.Labels(), 1)
 	log.I(l, "finished")
+}
+
+func (b *ProcessBatchWorker) checkErr(job *model.Job, err error) {
+	if err != nil {
+		job.TagError(b.Workers.MarathonDB, nameProcessBatchWorker, err.Error())
+		b.Workers.Statsd.Incr(processBatchWorkerError, job.Labels(), 1)
+
+		checkErr(b.Logger, err)
+	}
 }

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -182,6 +182,7 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 
 	if job.ExpiresAt > 0 && job.ExpiresAt < time.Now().UnixNano() {
 		log.I(l, "expired")
+		b.Workers.Statsd.Incr(ProcessBatchWorkerCompleted, job.Labels(), 1)
 		return
 	}
 
@@ -189,13 +190,16 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 	case "circuitbreak":
 		log.I(l, "circuit break")
 		b.moveJobToPausedQueue(job, message)
+		b.Workers.Statsd.Incr(ProcessBatchWorkerCompleted, job.Labels(), 1)
 		return
 	case "paused":
 		log.I(l, "paused")
 		b.moveJobToPausedQueue(job, message)
+		b.Workers.Statsd.Incr(ProcessBatchWorkerCompleted, job.Labels(), 1)
 		return
 	case "stopped":
 		log.I(l, "stopped")
+		b.Workers.Statsd.Incr(ProcessBatchWorkerCompleted, job.Labels(), 1)
 		return
 	default:
 		log.D(l, "valid")

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -178,7 +178,7 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 	b.checkErrWithReEnqueue(parsed, l, err)
 
 	log.D(l, "Retrieved job successfully.")
-	b.Workers.Statsd.Incr(processBatchWorkerStart, job.Labels(), 1)
+	b.Workers.Statsd.Incr(ProcessBatchWorkerStart, job.Labels(), 1)
 
 	if job.ExpiresAt > 0 && job.ExpiresAt < time.Now().UnixNano() {
 		log.I(l, "expired")
@@ -292,14 +292,14 @@ func (b *ProcessBatchWorker) Process(message *workers.Msg) {
 		b.checkErr(job, fmt.Errorf("failed to send message to several users, considering batch as failed"))
 	}
 
-	b.Workers.Statsd.Incr(processBatchWorkerCompleted, job.Labels(), 1)
+	b.Workers.Statsd.Incr(ProcessBatchWorkerCompleted, job.Labels(), 1)
 	log.I(l, "finished")
 }
 
 func (b *ProcessBatchWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
 		job.TagError(b.Workers.MarathonDB, nameProcessBatchWorker, err.Error())
-		b.Workers.Statsd.Incr(processBatchWorkerError, job.Labels(), 1)
+		b.Workers.Statsd.Incr(ProcessBatchWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}

--- a/worker/resume_job_worker.go
+++ b/worker/resume_job_worker.go
@@ -73,6 +73,7 @@ func (b *ResumeJobWorker) Process(message *workers.Msg) {
 		if err != nil && err != redis.Nil {
 			checkErr(b.Logger, err)
 		}
+		b.Workers.Statsd.Incr(ResumeJobWorkerCompleted, job.Labels(), 1)
 		return
 	}
 

--- a/worker/resume_job_worker.go
+++ b/worker/resume_job_worker.go
@@ -66,7 +66,7 @@ func (b *ResumeJobWorker) Process(message *workers.Msg) {
 
 	job, err := b.Workers.GetJob(id)
 	checkErr(l, err)
-	b.Workers.Statsd.Incr(resumeJobWorkerStart, job.Labels(), 1)
+	b.Workers.Statsd.Incr(ResumeJobWorkerStart, job.Labels(), 1)
 	if job.Status == stoppedJobStatus {
 		l.Info("stopped job resume_job_worker")
 		err := b.Workers.RedisClient.Del(fmt.Sprintf("%s-pausedjobs", jobID.(string))).Err()
@@ -92,14 +92,14 @@ func (b *ResumeJobWorker) Process(message *workers.Msg) {
 		b.checkErr(job, err)
 	}
 
-	b.Workers.Statsd.Incr(resumeJobWorkerCompleted, job.Labels(), 1)
+	b.Workers.Statsd.Incr(ResumeJobWorkerCompleted, job.Labels(), 1)
 	log.I(b.Logger, "finished resume_job_worker")
 }
 
 func (b *ResumeJobWorker) checkErr(job *model.Job, err error) {
 	if err != nil {
-		job.TagError(b.Workers.MarathonDB, resumeJobWorkerError, err.Error())
-		b.Workers.Statsd.Incr(resumeJobWorkerError, job.Labels(), 1)
+		job.TagError(b.Workers.MarathonDB, ResumeJobWorkerError, err.Error())
+		b.Workers.Statsd.Incr(ResumeJobWorkerError, job.Labels(), 1)
 
 		checkErr(b.Logger, err)
 	}


### PR DESCRIPTION
In order to have better tracking of all the worker's success and error rates, this PR adds `start`, `completed` and `error` metrics for each of the workers.