### PR TITLE
Send the job to process only after update job infos

### DIFF
--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -124,11 +124,10 @@ func (b *CreateBatchesWorker) processBatch(ids *[]string, job *model.Job) {
 	})
 
 	if numUsersFromBatch != 0 {
-		b.sendBatches(*usersFromBatch, job)
-
 		b.updateTotalUsers(job, numUsersFromBatch)
 		b.updateTotalBatches(1, job)
 		b.updateTotalTokens(numUsersFromBatch, job)
+		b.sendBatches(*usersFromBatch, job)
 	}
 }
 

--- a/worker/middleware_test.go
+++ b/worker/middleware_test.go
@@ -1,0 +1,38 @@
+package worker_test
+
+import (
+	"github.com/jrallison/go-workers"
+	uuid "github.com/satori/go.uuid"
+	"github.com/topfreegames/marathon/interfaces"
+	"github.com/topfreegames/marathon/model"
+)
+
+type ValidateCreateBatchesMiddleware struct {
+	IsTestRunning       bool
+	ResultChan          *chan bool
+	JobID               uuid.UUID
+	MarathonDB          interfaces.DB
+	ExpectedTotalUsers  int
+	ExpectedTotalTokens int
+}
+
+func (v *ValidateCreateBatchesMiddleware) Call(queue string, message *workers.Msg, next func() bool) (r bool) {
+	{
+		if !v.IsTestRunning {
+			return next()
+		}
+		r = false
+		if queue == "process_batch_worker" {
+
+			dbUpdated := false // check database state
+			job := &model.Job{}
+			err := v.MarathonDB.Model(job).Where("id = ?", v.JobID).Select()
+			if err == nil && job.TotalUsers == v.ExpectedTotalUsers && job.TotalTokens == v.ExpectedTotalTokens {
+				dbUpdated = true
+			}
+
+			*v.ResultChan <- dbUpdated
+		}
+		return
+	}
+}


### PR DESCRIPTION
Send the job to Redis before update TotalUsers, TotalBatches, and TotalTokens may cause race conditions on process batches worker because it evaluates job total batches as a condition to set the status.