### PR TITLE
fix: fail startup if cannnot connect to db

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -242,20 +242,30 @@ func (a *Application) configureApplication() {
 
 func (a *Application) configureDatabase() error {
 	PgClient, err := extensions.NewPGClient("db", a.Config, a.Logger)
-	a.DB = PgClient.DB
-	if err == nil {
-		log.I(a.Logger, "successfully connected to the marathon database")
+	if err != nil {
+		log.E(a.Logger, "Failed to initialize Marathon Database.", func(cm log.CM) {
+			cm.Write(zap.Error(err))
+		})
+		return err
 	}
-	return err
+
+	a.DB = PgClient.DB
+	log.I(a.Logger, "successfully connected to the marathon database")
+	return nil
 }
 
 func (a *Application) configurePushDatabase() error {
 	PgClient, err := extensions.NewPGClient("push.db", a.Config, a.Logger)
-	a.PushDB = PgClient.DB
-	if err == nil {
-		log.I(a.Logger, "successfully connected to the push database")
+	if err != nil {
+		log.E(a.Logger, "Failed to initialize Push Database.", func(cm log.CM) {
+			cm.Write(zap.Error(err))
+		})
+		return err
 	}
-	return err
+
+	a.PushDB = PgClient.DB
+	log.I(a.Logger, "successfully connected to the push database")
+	return nil
 }
 
 func (a *Application) configureSendgrid() {

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -25,13 +25,12 @@ package api_test
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/marathon/api"
 	. "github.com/topfreegames/marathon/testing"
 	"github.com/uber-go/zap"
+	"net/http"
 )
 
 var _ = Describe("API Application", func() {
@@ -95,6 +94,10 @@ var _ = Describe("API Application", func() {
 			Expect(obj["msg"]).To(Equal("Panic occurred."))
 			Expect(obj["operation"]).To(Equal("OnErrorHandler"))
 			Expect(obj["stack"]).To(Equal("stack"))
+		})
+
+		It("should panic on DB connect error", func() {
+			Expect(func() { api.GetApplication("127.0.0.1", 9999, false, logger, GetFaultyDBConfPath()) }).To(PanicWith("cannot configure application"))
 		})
 	})
 })

--- a/config/test-faulty-db.yaml
+++ b/config/test-faulty-db.yaml
@@ -2,30 +2,28 @@
 db:
   host: localhost
   port: 8585
-  user: postgres
-  pass: ""
+  user: marathon_test_user
+  password: ""
   poolSize: 20
   maxRetries: 3
-  database: marathon
+  database: marathon_faulty
 push:
   db:
     host: localhost
     port: 8585
-    user: marathon_user
+    user: marathon_test_user
     pass: ""
     poolSize: 20
     maxRetries: 3
-    database: push
+    database: marathon_test
 s3:
   bucket: "tfg-push-notifications"
+  folder: "test/jobs"
+  controlGroupFolder: "test/control-groups"
   region: "us-east-1"
-  folder: "development/jobs"
-  controlGroupFolder: "development/control-groups"
   daysExpiry: 1
   accessKey: "ACCESS-KEY"
   secretAccessKey: "SECRET-ACCESS-KEY"
-kafka:
-  bootstrapServers: localhost:9940
 workers:
   statsPort: 8081
   direct:
@@ -58,11 +56,10 @@ workers:
     maxRetries: 5
   redis:
     poolSize: 10
-    host: 0.0.0.0
+    host: localhost
     port: 6333
     db: 0
     pass:
-    tlsEnabled: true
   topicTemplate: "%s-%s-c"
 feedbackListener:
   flushInterval: 5000
@@ -70,8 +67,8 @@ feedbackListener:
   kafka:
     topics:
       - "^.*-feedbacks$"
+    brokers: localhost:9940
     group: marathon-consumer-group
     sessionTimeout: 6000
     handleAllMessagesBeforeExiting: true
     offsetResetStrategy: latest
-    brokers: localhost:9092

--- a/db/create.sql
+++ b/db/create.sql
@@ -6,3 +6,9 @@ CREATE DATABASE marathon
        ENCODING = 'UTF8'
        TABLESPACE = pg_default
        TEMPLATE = template0;
+
+CREATE DATABASE push
+  WITH OWNER = marathon_user
+       ENCODING = 'UTF8'
+       TABLESPACE = pg_default
+       TEMPLATE = template0;

--- a/extensions/pg.go
+++ b/extensions/pg.go
@@ -24,6 +24,7 @@ package extensions
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
@@ -93,6 +94,10 @@ func (c *PGClient) Connect(prefix string, PGOrNil ...interfaces.DB) error {
 
 	conn := pg.Connect(opts)
 	c.DB = conn
+
+	if !c.IsConnected() {
+		return errors.New("cannot connect to DB")
+	}
 
 	return nil
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -419,6 +419,13 @@ func GetConfPath() string {
 	return conf
 }
 
+//GetFaultyDBConfPath return faulty DB config for testing
+func GetFaultyDBConfPath() string {
+	conf := "../config/test-faulty-db.yaml"
+	return conf
+}
+
+
 //GetConf returns a viper config for the environment we're in
 func GetConf() *viper.Viper {
 	confPath := GetConfPath()


### PR DESCRIPTION
During PG connect, try to run a `SELECT 1` command to try and check if the DB is live. If not, fails the app startup with a panic