### PR TITLE
Feat/dispatch fcm first routing

### DIFF
--- a/extensions/kafka_producer.go
+++ b/extensions/kafka_producer.go
@@ -174,6 +174,34 @@ func (c *KafkaProducer) SendGCMPush(topic, deviceToken string, payload, messageM
 	return nil
 }
 
+//SendFCMPush sends an iOS FCM push to Kafka in pusher's firebase wire shape
+//(top-level notification). Unlike SendGCMPush, the rendered alert lands in the
+//notification block so pusher's buildIOSMessage produces a non-empty aps.alert.
+func (c *KafkaProducer) SendFCMPush(topic, deviceToken string, payload, messageMetadata map[string]interface{}, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) error {
+	msg := messages.NewFCMMessage(
+		deviceToken,
+		payload,
+		messageMetadata,
+		pushMetadata,
+		pushExpiry,
+		templateName,
+	)
+
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.To = GenerateFakeID(152)
+			msg.DryRun = true
+		}
+	}
+
+	message, err := msg.ToJSON()
+	if err != nil {
+		return err
+	}
+	c.sendPush(messages.NewKafkaMessage(topic, message))
+	return nil
+}
+
 //SendPush notification to Kafka
 func (c *KafkaProducer) sendPush(msg *messages.KafkaMessage) {
 	message := &sarama.ProducerMessage{

--- a/interfaces/push_producer.go
+++ b/interfaces/push_producer.go
@@ -26,4 +26,7 @@ package interfaces
 type PushProducer interface {
 	SendAPNSPush(topic, deviceToken string, payload, messageMetadata map[string]interface{}, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) error
 	SendGCMPush(topic, deviceToken string, payload, messageMetadata map[string]interface{}, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) error
+	// SendFCMPush sends an iOS push through FCM in pusher's firebase wire shape
+	// (top-level notification), used by FCM-first routing on the _ios topic.
+	SendFCMPush(topic, deviceToken string, payload, messageMetadata map[string]interface{}, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) error
 }

--- a/messages/fcm.go
+++ b/messages/fcm.go
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2016 TFG Co <backend@tfgco.com>
+ * Author: TFG Co <backend@tfgco.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package messages
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Notification mirrors the notification block consumed by pusher's firebase
+// message handler (interfaces.Message.Notification). pusher's buildIOSMessage
+// builds the APNs `aps.alert` ONLY from these top-level fields — never from
+// `data` — so the FCM-iOS dispatch path MUST populate this. This is the
+// asymmetry with the Android `gcm` path: Android renders data messages
+// client-side, iOS needs a real `aps.alert` or the push is silent.
+type Notification struct {
+	Title        string `json:"title,omitempty"`
+	Body         string `json:"body,omitempty"`
+	Sound        string `json:"sound,omitempty"`
+	Badge        string `json:"badge,omitempty"`
+	BodyLocKey   string `json:"body_loc_key,omitempty"`
+	BodyLocArgs  string `json:"body_loc_args,omitempty"`
+	TitleLocKey  string `json:"title_loc_key,omitempty"`
+	TitleLocArgs string `json:"title_loc_args,omitempty"`
+	ImageURL     string `json:"image_url,omitempty"`
+}
+
+// FCMMessage is the wire shape pusher's firebase consumer expects on the
+// push-<game>_ios-<size> topic: a generic message carrying a TOP-LEVEL
+// notification (interfaces.Message + kafkaFCMMessage's metadata/push_expiry).
+//
+// It is deliberately NOT a GCMMessage. GCMMessage puts the whole template under
+// `data`, and pusher's buildIOSMessage ignores `data` when building `aps`, so a
+// GCMMessage delivered on the _ios topic produces an empty `aps` (a silent
+// push). FCMMessage carries the rendered alert in `notification` so iOS renders
+// a banner.
+type FCMMessage struct {
+	To               string                 `json:"to"`
+	Notification     *Notification          `json:"notification,omitempty"`
+	ContentAvailable bool                   `json:"content_available,omitempty"`
+	Data             map[string]interface{} `json:"data,omitempty"`
+	DryRun           bool                   `json:"dry_run"`
+	PushExpiry       int64                  `json:"push_expiry,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// NewFCMMessage builds an FCMMessage from an APNs-shaped template payload (the
+// same payload the apns path feeds into Payload.aps). The APNs alert/sound/
+// badge/content-available are mapped onto pusher's notification block; custom
+// message data (`m`) and templateName are carried in `data` to match the gcm
+// path. `pushExpiry` is given in seconds (expiresAt/1e9) and converted here.
+func NewFCMMessage(to string, payload, messageMetadata, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) *FCMMessage {
+	if payload == nil {
+		payload = map[string]interface{}{}
+	}
+
+	data := map[string]interface{}{
+		"templateName": templateName,
+	}
+	if len(messageMetadata) > 0 {
+		data["m"] = messageMetadata
+	}
+
+	msg := &FCMMessage{
+		To:               to,
+		Notification:     apsAlertToNotification(payload),
+		ContentAvailable: apsContentAvailable(payload),
+		Data:             data,
+		DryRun:           false,
+		Metadata:         pushMetadata,
+	}
+
+	// pusher's firebase handler drops messages whose push_expiry has already
+	// passed, comparing against MakeTimestamp() which is in MILLISECONDS.
+	// marathon's pushExpiry is absolute unix SECONDS, so convert. A zero value
+	// means "no expiry" and is left unset so the check is skipped — exactly how
+	// the Android gcm path (which has no push_expiry field) behaves.
+	if pushExpiry > 0 {
+		msg.PushExpiry = pushExpiry * 1000
+	}
+
+	return msg
+}
+
+// apsAlertToNotification maps an APNs aps payload onto pusher's notification
+// block. APNs `alert` may be a plain string (the body) or a dict with
+// title/body/loc keys. `sound` may be a string or a critical-alert dict.
+// Options pusher's Notification cannot represent (mutable-content, thread-id,
+// category, interruption-level, subtitle) are dropped — closing that gap is a
+// pusher-side change to interfaces.Message/buildIOSMessage.
+func apsAlertToNotification(payload map[string]interface{}) *Notification {
+	n := &Notification{}
+
+	switch alert := payload["alert"].(type) {
+	case string:
+		n.Body = alert
+	case map[string]interface{}:
+		n.Title = stringField(alert, "title")
+		n.Body = stringField(alert, "body")
+		n.TitleLocKey = stringField(alert, "title-loc-key")
+		n.BodyLocKey = stringField(alert, "loc-key")
+		n.TitleLocArgs = joinLocArgs(alert["title-loc-args"])
+		n.BodyLocArgs = joinLocArgs(alert["loc-args"])
+	}
+
+	switch sound := payload["sound"].(type) {
+	case string:
+		n.Sound = sound
+	case map[string]interface{}:
+		// Critical-alert sound dictionary: {critical, name, volume}.
+		n.Sound = stringField(sound, "name")
+	}
+
+	if badge, ok := payload["badge"]; ok {
+		n.Badge = numberToString(badge)
+	}
+
+	if *n == (Notification{}) {
+		return nil
+	}
+	return n
+}
+
+// apsContentAvailable reports whether the aps payload requests a
+// content-available (silent/background) push. It is a top-level message field
+// in pusher's shape, not part of the notification block.
+func apsContentAvailable(payload map[string]interface{}) bool {
+	switch v := payload["content-available"].(type) {
+	case bool:
+		return v
+	case float64:
+		return v == 1
+	case int:
+		return v == 1
+	case string:
+		return v == "1" || v == "true"
+	}
+	return false
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// joinLocArgs flattens APNs loc-args (a JSON array) into the single string
+// pusher's Notification models (pusher re-wraps it into a one-element array).
+// Multiple args are comma-joined — a known parity limitation of pusher's shape.
+func joinLocArgs(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []interface{}:
+		parts := make([]string, 0, len(t))
+		for _, e := range t {
+			parts = append(parts, fmt.Sprintf("%v", e))
+		}
+		return strings.Join(parts, ",")
+	}
+	return ""
+}
+
+// numberToString renders an APNs badge (a JSON number) as the string pusher's
+// Notification.Badge expects. JSON numbers decode to float64; integers are
+// rendered without a trailing ".0".
+func numberToString(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case json.Number:
+		return t.String()
+	}
+	return ""
+}
+
+// ToJSON returns the serialized message.
+func (m *FCMMessage) ToJSON() (string, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/messages/fcm_test.go
+++ b/messages/fcm_test.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016 TFG Co <backend@tfgco.com>
+ * Author: TFG Co <backend@tfgco.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package messages_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/marathon/messages"
+)
+
+var _ = Describe("FCM Message", func() {
+	Describe("Creating new message", func() {
+		It("maps a string aps alert to notification.body (the visible banner)", func() {
+			payload := map[string]interface{}{"alert": "Everyone just liked your village!"}
+			msg := messages.NewFCMMessage("fcm-token", payload, nil, nil, 0, "my-template")
+
+			Expect(msg).NotTo(BeNil())
+			Expect(msg.To).To(Equal("fcm-token"))
+			Expect(msg.Notification).NotTo(BeNil())
+			Expect(msg.Notification.Body).To(Equal("Everyone just liked your village!"))
+			Expect(msg.Notification.Title).To(Equal(""))
+			Expect(msg.DryRun).To(Equal(false))
+		})
+
+		It("maps a dictionary aps alert to title/body and loc keys", func() {
+			payload := map[string]interface{}{
+				"alert": map[string]interface{}{
+					"title":         "Village",
+					"body":          "Someone liked it",
+					"title-loc-key": "TITLE_KEY",
+					"loc-key":       "BODY_KEY",
+					"loc-args":      []interface{}{"Everyone", "village"},
+				},
+			}
+			msg := messages.NewFCMMessage("fcm-token", payload, nil, nil, 0, "tpl")
+
+			Expect(msg.Notification).NotTo(BeNil())
+			Expect(msg.Notification.Title).To(Equal("Village"))
+			Expect(msg.Notification.Body).To(Equal("Someone liked it"))
+			Expect(msg.Notification.TitleLocKey).To(Equal("TITLE_KEY"))
+			Expect(msg.Notification.BodyLocKey).To(Equal("BODY_KEY"))
+			Expect(msg.Notification.BodyLocArgs).To(Equal("Everyone,village"))
+		})
+
+		It("maps sound, badge and content-available", func() {
+			payload := map[string]interface{}{
+				"alert":             "hi",
+				"sound":             "chime.caf",
+				"badge":             float64(7),
+				"content-available": float64(1),
+			}
+			msg := messages.NewFCMMessage("fcm-token", payload, nil, nil, 0, "tpl")
+
+			Expect(msg.Notification.Sound).To(Equal("chime.caf"))
+			Expect(msg.Notification.Badge).To(Equal("7"))
+			Expect(msg.ContentAvailable).To(BeTrue())
+		})
+
+		It("reads the name from a critical-alert sound dictionary", func() {
+			payload := map[string]interface{}{
+				"alert": "hi",
+				"sound": map[string]interface{}{"critical": float64(1), "name": "siren.caf", "volume": 1.0},
+			}
+			msg := messages.NewFCMMessage("fcm-token", payload, nil, nil, 0, "tpl")
+			Expect(msg.Notification.Sound).To(Equal("siren.caf"))
+		})
+
+		It("carries templateName and message metadata in data (parity with gcm)", func() {
+			mtd := map[string]interface{}{"deeplink": "village/123"}
+			msg := messages.NewFCMMessage("fcm-token", map[string]interface{}{"alert": "hi"}, mtd, nil, 0, "my-template")
+
+			Expect(msg.Data["templateName"]).To(Equal("my-template"))
+			Expect(msg.Data["m"]).To(BeEquivalentTo(mtd))
+		})
+
+		It("passes pushMetadata through to the top-level metadata field", func() {
+			pmtd := map[string]interface{}{"userId": "u1", "pushType": "massive"}
+			msg := messages.NewFCMMessage("fcm-token", map[string]interface{}{"alert": "hi"}, nil, pmtd, 0, "tpl")
+			Expect(msg.Metadata).To(BeEquivalentTo(pmtd))
+		})
+
+		It("returns a nil notification when the payload has no alert or sound/badge", func() {
+			msg := messages.NewFCMMessage("fcm-token", map[string]interface{}{"content-available": float64(1)}, nil, nil, 0, "tpl")
+			Expect(msg.Notification).To(BeNil())
+			Expect(msg.ContentAvailable).To(BeTrue())
+		})
+
+		It("tolerates a nil payload", func() {
+			msg := messages.NewFCMMessage("fcm-token", nil, nil, nil, 0, "tpl")
+			Expect(msg).NotTo(BeNil())
+			Expect(msg.Notification).To(BeNil())
+		})
+
+		Describe("push_expiry (the seconds->milliseconds seam)", func() {
+			It("converts seconds to the milliseconds pusher's MakeTimestamp compares against", func() {
+				// 1_700_000_000s -> 1_700_000_000_000ms. If left in seconds, pusher
+				// would treat every iOS message as already expired and silently drop it.
+				msg := messages.NewFCMMessage("fcm-token", map[string]interface{}{"alert": "hi"}, nil, nil, 1700000000, "tpl")
+				Expect(msg.PushExpiry).To(Equal(int64(1700000000000)))
+			})
+
+			It("omits push_expiry when there is no expiry (zero)", func() {
+				msg := messages.NewFCMMessage("fcm-token", map[string]interface{}{"alert": "hi"}, nil, nil, 0, "tpl")
+				Expect(msg.PushExpiry).To(Equal(int64(0)))
+
+				msgStr, err := msg.ToJSON()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(msgStr).NotTo(ContainSubstring("push_expiry"))
+			})
+		})
+
+		Describe("wire format", func() {
+			It("serializes the alert as a TOP-LEVEL notification, not buried in data", func() {
+				payload := map[string]interface{}{"alert": "Everyone just liked your village!"}
+				msg := messages.NewFCMMessage("fcm-token", payload, nil, nil, 0, "tpl")
+				msgStr, err := msg.ToJSON()
+				Expect(err).NotTo(HaveOccurred())
+
+				// Decode generically and assert the shape pusher's buildIOSMessage reads.
+				var decoded map[string]interface{}
+				Expect(json.Unmarshal([]byte(msgStr), &decoded)).To(Succeed())
+
+				notification, ok := decoded["notification"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "notification must be a top-level object")
+				Expect(notification["body"]).To(Equal("Everyone just liked your village!"))
+
+				// The rendered alert must NOT live under data (that is the gcm shape
+				// that yields a silent push on iOS).
+				if data, ok := decoded["data"].(map[string]interface{}); ok {
+					Expect(data).NotTo(HaveKey("alert"))
+				}
+			})
+		})
+	})
+})

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -50,6 +50,8 @@ import (
 type FakeKafkaProducer struct {
 	APNSMessages []string
 	GCMMessages  []string
+	APNSTopics   []string
+	GCMTopics    []string
 }
 
 // NewFakeKafkaProducer creates a new FakeKafkaProducer
@@ -57,6 +59,8 @@ func NewFakeKafkaProducer() *FakeKafkaProducer {
 	return &FakeKafkaProducer{
 		APNSMessages: []string{},
 		GCMMessages:  []string{},
+		APNSTopics:   []string{},
+		GCMTopics:    []string{},
 	}
 }
 
@@ -83,6 +87,7 @@ func (f *FakeKafkaProducer) SendAPNSPush(topic, deviceToken string, payload, mes
 	}
 
 	f.APNSMessages = append(f.APNSMessages, message)
+	f.APNSTopics = append(f.APNSTopics, topic)
 
 	return nil
 }
@@ -112,6 +117,7 @@ func (f *FakeKafkaProducer) SendGCMPush(topic, deviceToken string, payload, mess
 	}
 
 	f.GCMMessages = append(f.GCMMessages, message)
+	f.GCMTopics = append(f.GCMTopics, topic)
 
 	return nil
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -50,8 +50,10 @@ import (
 type FakeKafkaProducer struct {
 	APNSMessages []string
 	GCMMessages  []string
+	FCMMessages  []string
 	APNSTopics   []string
 	GCMTopics    []string
+	FCMTopics    []string
 }
 
 // NewFakeKafkaProducer creates a new FakeKafkaProducer
@@ -59,8 +61,10 @@ func NewFakeKafkaProducer() *FakeKafkaProducer {
 	return &FakeKafkaProducer{
 		APNSMessages: []string{},
 		GCMMessages:  []string{},
+		FCMMessages:  []string{},
 		APNSTopics:   []string{},
 		GCMTopics:    []string{},
+		FCMTopics:    []string{},
 	}
 }
 
@@ -118,6 +122,35 @@ func (f *FakeKafkaProducer) SendGCMPush(topic, deviceToken string, payload, mess
 
 	f.GCMMessages = append(f.GCMMessages, message)
 	f.GCMTopics = append(f.GCMTopics, topic)
+
+	return nil
+}
+
+// SendFCMPush for testing
+func (f *FakeKafkaProducer) SendFCMPush(topic, deviceToken string, payload, messageMetadata map[string]interface{}, pushMetadata map[string]interface{}, pushExpiry int64, templateName string) error {
+	msg := messages.NewFCMMessage(
+		deviceToken,
+		payload,
+		messageMetadata,
+		pushMetadata,
+		pushExpiry,
+		templateName,
+	)
+
+	if val, ok := pushMetadata["dryRun"]; ok {
+		if dryRun, _ := val.(bool); dryRun {
+			msg.To = extensions.GenerateFakeID(152)
+			msg.DryRun = true
+		}
+	}
+
+	message, err := msg.ToJSON()
+	if err != nil {
+		return err
+	}
+
+	f.FCMMessages = append(f.FCMMessages, message)
+	f.FCMTopics = append(f.FCMTopics, topic)
 
 	return nil
 }

--- a/worker/create_batches_fcm_probe_internal_test.go
+++ b/worker/create_batches_fcm_probe_internal_test.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016 TFG Co <backend@tfgco.com>
+ *
+ * Internal (package worker) tests for the dispatch-time FCM-first routing
+ * support on the create-batches read path: the fcm_token column probe, its
+ * process-lifetime cache, and the column-aware SELECT in getUserBatchFromPG.
+ */
+
+package worker
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/marathon/model"
+	"github.com/uber-go/zap"
+)
+
+// confPath mirrors testing.GetConfPath(); the testing package can't be imported
+// here (it pulls in api -> worker, an import cycle for an internal test).
+const confPath = "../config/test.yaml"
+
+var _ = Describe("CreateBatches FCM token probe", func() {
+	logger := zap.New(zap.NewJSONEncoder(zap.NoTime()), zap.FatalLevel)
+	w := NewWorker(logger, confPath)
+	b := &CreateBatchesWorker{Workers: w}
+
+	dropTables := func(tables ...string) {
+		for _, t := range tables {
+			_, err := w.PushDB.Exec("DROP TABLE IF EXISTS " + t)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	BeforeEach(func() {
+		// Reset the process-lifetime cache so each spec starts clean; the cache
+		// is package-global and otherwise leaks across specs.
+		fcmTokenColumnCacheMu.Lock()
+		fcmTokenColumnCache = map[string]bool{}
+		fcmTokenColumnCacheMu.Unlock()
+	})
+
+	Describe("pushTableHasFcmToken", func() {
+		It("reports true for a table carrying the fcm_token column", func() {
+			dropTables("probewith_apns")
+			_, err := w.PushDB.Exec(`CREATE TABLE probewith_apns (
+				user_id text, token text, locale text, tz text, fcm_token text)`)
+			Expect(err).NotTo(HaveOccurred())
+			defer dropTables("probewith_apns")
+
+			Expect(b.pushTableHasFcmToken("probewith_apns")).To(BeTrue())
+		})
+
+		It("reports false for a table without the fcm_token column", func() {
+			dropTables("probewithout_apns")
+			_, err := w.PushDB.Exec(`CREATE TABLE probewithout_apns (
+				user_id text, token text, locale text, tz text)`)
+			Expect(err).NotTo(HaveOccurred())
+			defer dropTables("probewithout_apns")
+
+			Expect(b.pushTableHasFcmToken("probewithout_apns")).To(BeFalse())
+		})
+
+		It("reports false when the table does not exist", func() {
+			dropTables("probemissing_apns")
+			Expect(b.pushTableHasFcmToken("probemissing_apns")).To(BeFalse())
+		})
+
+		It("caches the first result for the process lifetime (migrate-while-running needs a restart)", func() {
+			dropTables("probecache_apns")
+			_, err := w.PushDB.Exec(`CREATE TABLE probecache_apns (
+				user_id text, token text, locale text, tz text)`)
+			Expect(err).NotTo(HaveOccurred())
+			defer dropTables("probecache_apns")
+
+			// First probe: no column -> false, and that's cached.
+			Expect(b.pushTableHasFcmToken("probecache_apns")).To(BeFalse())
+
+			// Add the column after the cache was populated.
+			_, err = w.PushDB.Exec("ALTER TABLE probecache_apns ADD COLUMN fcm_token text")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Still false: the cached value is served, mirroring push-api's AR
+			// column cache. A restart (cache reset) is required to see the column.
+			Expect(b.pushTableHasFcmToken("probecache_apns")).To(BeFalse())
+
+			fcmTokenColumnCacheMu.Lock()
+			fcmTokenColumnCache = map[string]bool{}
+			fcmTokenColumnCacheMu.Unlock()
+
+			// After a "restart" the freshly-probed table now reports the column.
+			Expect(b.pushTableHasFcmToken("probecache_apns")).To(BeTrue())
+		})
+	})
+
+	Describe("getUserBatchFromPG", func() {
+		It("populates User.FcmToken from a migrated table", func() {
+			dropTables("fcmread_apns")
+			_, err := w.PushDB.Exec(`CREATE TABLE fcmread_apns (
+				user_id text, token text, locale text, tz text, fcm_token text)`)
+			Expect(err).NotTo(HaveOccurred())
+			defer dropTables("fcmread_apns")
+			_, err = w.PushDB.Exec(`INSERT INTO fcmread_apns (user_id, token, locale, tz, fcm_token)
+				VALUES ('u1', 'apns-tok-1', 'en', '-0300', 'fcm-tok-1'),
+				       ('u2', 'apns-tok-2', 'en', '-0300', NULL)`)
+			Expect(err).NotTo(HaveOccurred())
+
+			job := &model.Job{Service: "apns", App: model.App{Name: "fcmread"}}
+			ids := []string{"u1", "u2"}
+			users := *b.getUserBatchFromPG(&ids, job)
+
+			byID := map[string]User{}
+			for _, u := range users {
+				byID[u.UserID] = u
+			}
+			Expect(byID).To(HaveLen(2))
+			Expect(byID["u1"].FcmToken).To(Equal("fcm-tok-1"))
+			Expect(byID["u1"].Token).To(Equal("apns-tok-1"))
+			// NULL fcm_token decodes to the empty string -> APNs fallback at dispatch.
+			Expect(byID["u2"].FcmToken).To(Equal(""))
+			Expect(byID["u2"].Token).To(Equal("apns-tok-2"))
+		})
+
+		It("reads a non-migrated table without error and leaves FcmToken empty", func() {
+			dropTables("nofcmread_apns")
+			_, err := w.PushDB.Exec(`CREATE TABLE nofcmread_apns (
+				user_id text, token text, locale text, tz text)`)
+			Expect(err).NotTo(HaveOccurred())
+			defer dropTables("nofcmread_apns")
+			_, err = w.PushDB.Exec(`INSERT INTO nofcmread_apns (user_id, token, locale, tz)
+				VALUES ('u1', 'apns-tok-1', 'en', '-0300')`)
+			Expect(err).NotTo(HaveOccurred())
+
+			job := &model.Job{Service: "apns", App: model.App{Name: "nofcmread"}}
+			ids := []string{"u1"}
+			users := *b.getUserBatchFromPG(&ids, job)
+
+			Expect(users).To(HaveLen(1))
+			Expect(users[0].Token).To(Equal("apns-tok-1"))
+			Expect(users[0].FcmToken).To(Equal(""))
+		})
+	})
+})

--- a/worker/create_batches_worker.go
+++ b/worker/create_batches_worker.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 
 	goworkers2 "github.com/digitalocean/go-workers2"
@@ -43,6 +44,13 @@ import (
 
 const nameCreateBatches = "create_batches_worker"
 const uuidSizeBytes = 36
+
+// fcmTokenColumnCache memoizes, per push table, whether the fcm_token column
+// exists. Process-lifetime cache; see pushTableHasFcmToken.
+var (
+	fcmTokenColumnCache   = map[string]bool{}
+	fcmTokenColumnCacheMu sync.RWMutex
+)
 
 // CreateBatchesWorker is the CreateBatchesWorker struct
 type CreateBatchesWorker struct {
@@ -104,12 +112,48 @@ func (b *CreateBatchesWorker) updateCompletedAt(unixTime int64, job *model.Job) 
 func (b *CreateBatchesWorker) getUserBatchFromPG(userIds *[]string, job *model.Job) *[]User {
 	var users []User
 	start := time.Now()
-	query := fmt.Sprintf("SELECT user_id, token, locale, tz FROM %s WHERE user_id IN (?)", GetPushDBTableName(job.App.Name, job.Service))
+	table := GetPushDBTableName(job.App.Name, job.Service)
+	columns := "user_id, token, locale, tz"
+	// fcm_token only exists on migrated <game>_apns tables. Selecting it on a
+	// table without the column errors, so probe (cached) and add it only when present.
+	if b.pushTableHasFcmToken(table) {
+		columns += ", fcm_token"
+	}
+	query := fmt.Sprintf("SELECT %s FROM %s WHERE user_id IN (?)", columns, table)
 	_, err := b.Workers.PushDB.Query(&users, query, pg.In(*userIds))
 	b.Workers.Statsd.Timing("get_csv_batch_from_pg", time.Now().Sub(start), job.Labels(), 1)
 
 	b.checkErr(job, err)
 	return &users
+}
+
+// pushTableHasFcmToken reports whether the given push table carries the
+// fcm_token column, cached for the process lifetime. Like push-api's AR column
+// cache, a game migrated while marathon is running is not seen until restart —
+// restart-after-migration is part of the per-game rollout.
+func (b *CreateBatchesWorker) pushTableHasFcmToken(table string) bool {
+	fcmTokenColumnCacheMu.RLock()
+	has, ok := fcmTokenColumnCache[table]
+	fcmTokenColumnCacheMu.RUnlock()
+	if ok {
+		return has
+	}
+
+	var exists bool
+	_, err := b.Workers.PushDB.QueryOne(
+		pg.Scan(&exists),
+		"SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = ? AND column_name = 'fcm_token')",
+		table,
+	)
+	if err != nil {
+		// Conservative: on probe failure assume no column so dispatch stays on APNs.
+		return false
+	}
+
+	fcmTokenColumnCacheMu.Lock()
+	fcmTokenColumnCache[table] = exists
+	fcmTokenColumnCacheMu.Unlock()
+	return exists
 }
 
 func (b *CreateBatchesWorker) processBatch(ids *[]string, job *model.Job) {

--- a/worker/metrics.go
+++ b/worker/metrics.go
@@ -20,6 +20,9 @@ const (
 	ProcessBatchWorkerStart     = "starting_process_batch_worker"
 	ProcessBatchWorkerCompleted = "completed_process_batch_worker"
 	ProcessBatchWorkerError     = "error_process_batch_worker"
+	// ProcessBatchWorkerRouted counts dispatches tagged by provider (apns/fcm/gcm)
+	// and game; per-game iOS migration state = fcm / (fcm + apns).
+	ProcessBatchWorkerRouted = "routed_process_batch_worker"
 
 	ResumeJobWorkerStart     = "starting_resume_job_worker"
 	ResumeJobWorkerCompleted = "completed_resume_job_worker"

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -222,9 +222,15 @@ func (b *ProcessBatchWorker) Process(message *goworkers2.Msg) error {
 	})
 
 	topicTemplate := b.Workers.Config.GetString("workers.topicTemplate")
-	topic := BuildTopicName(parsed.AppName, job.Service, topicTemplate)
+	apnsTopic := BuildTopicName(parsed.AppName, job.Service, topicTemplate)
+	// FCM-first iOS routing publishes to the _ios topic (service token swapped),
+	// keeping the env-specific template intact. Only relevant for apns jobs.
+	iosTopic := ""
+	if job.Service == "apns" {
+		iosTopic = BuildTopicName(parsed.AppName, "ios", topicTemplate)
+	}
 	log.D(l, "Built topic name successfully.", func(cm log.CM) {
-		cm.Write(zap.String("topic", topic))
+		cm.Write(zap.String("topic", apnsTopic))
 	})
 	for _, user := range parsed.Users {
 		templateName := job.TemplateName
@@ -275,21 +281,30 @@ func (b *ProcessBatchWorker) Process(message *goworkers2.Msg) error {
 			}
 		}
 
-		err = b.sendToKafka(job.Service, topic, msg, job.Metadata, pushMetadata, user.Token, job.ExpiresAt, templateName)
+		// FCM-first: an apns-service device carrying an fcm_token dispatches through
+		// FCM (gcm wire shape) to the _ios topic; otherwise APNs. Token presence is
+		// the switch, APNs is the structural fallback — no per-game flag.
+		sendService, topic, deviceToken, provider := job.Service, apnsTopic, user.Token, job.Service
+		if job.Service == "apns" && user.FcmToken != "" {
+			sendService, topic, deviceToken, provider = "gcm", iosTopic, user.FcmToken, "fcm"
+		}
+
+		err = b.sendToKafka(sendService, topic, msg, job.Metadata, pushMetadata, deviceToken, job.ExpiresAt, templateName)
 		if err != nil {
 			batchErrorCounter = batchErrorCounter + 1
 			log.E(l, "Failed to send message to Kafka.", func(cm log.CM) {
 				cm.Write(
-					zap.String("service", job.Service),
+					zap.String("service", sendService),
 					zap.String("topic", topic),
 					zap.Object("msg", msg),
 					zap.Object("metadata", job.Metadata),
-					zap.Object("token", user.Token),
+					zap.Object("token", deviceToken),
 					zap.Object("expiresAt", job.ExpiresAt),
 					zap.Error(err),
 				)
 			})
 		}
+		b.Workers.Statsd.Incr(ProcessBatchWorkerRouted, []string{"game:" + parsed.AppName, "provider:" + provider}, 1)
 	}
 	log.D(l, "Sent push to pusher for batch users.")
 	err = b.updateJobBatchesInfo(parsed.JobID)

--- a/worker/process_batch_worker.go
+++ b/worker/process_batch_worker.go
@@ -95,8 +95,15 @@ func (b *ProcessBatchWorker) sendToKafka(service, topic string, msg, messageMeta
 		if err != nil {
 			return err
 		}
+	case "fcm":
+		// FCM-first iOS dispatch: pusher's firebase consumer needs a top-level
+		// notification (not the gcm data-only shape) to render an aps.alert.
+		err := b.Workers.Kafka.SendFCMPush(topic, deviceToken, msg, messageMetadata, pushMetadata, pushExpiry, templateName)
+		if err != nil {
+			return err
+		}
 	default:
-		panic("service should be in ['apns', 'gcm']")
+		panic("service should be in ['apns', 'gcm', 'fcm']")
 	}
 	return nil
 }
@@ -282,11 +289,12 @@ func (b *ProcessBatchWorker) Process(message *goworkers2.Msg) error {
 		}
 
 		// FCM-first: an apns-service device carrying an fcm_token dispatches through
-		// FCM (gcm wire shape) to the _ios topic; otherwise APNs. Token presence is
-		// the switch, APNs is the structural fallback — no per-game flag.
+		// FCM to the _ios topic (using the fcm wire shape so pusher renders a
+		// visible aps.alert); otherwise APNs. Token presence is the switch, APNs is
+		// the structural fallback — no per-game flag.
 		sendService, topic, deviceToken, provider := job.Service, apnsTopic, user.Token, job.Service
 		if job.Service == "apns" && user.FcmToken != "" {
-			sendService, topic, deviceToken, provider = "gcm", iosTopic, user.FcmToken, "fcm"
+			sendService, topic, deviceToken, provider = "fcm", iosTopic, user.FcmToken, "fcm"
 		}
 
 		err = b.sendToKafka(sendService, topic, msg, job.Metadata, pushMetadata, deviceToken, job.ExpiresAt, templateName)

--- a/worker/process_batch_worker_test.go
+++ b/worker/process_batch_worker_test.go
@@ -219,6 +219,55 @@ var _ = Describe("ProcessBatch Worker", func() {
 			}
 		})
 
+		It("routes apns devices with an fcm_token through FCM to the _ios topic, others to apns", func() {
+			appName := strings.Split(app.BundleID, ".")[2]
+			apnsJob := CreateTestJob(w.MarathonDB, app.ID, template.Name, map[string]interface{}{
+				"context": context,
+				"service": "apns",
+			})
+
+			fcmToken := "fcm-" + strings.Replace(uuid.NewV4().String(), "-", "", -1)
+			routingUsers := []worker.User{
+				{
+					UserID:   uuid.NewV4().String(),
+					Token:    strings.Replace(uuid.NewV4().String(), "-", "", -1),
+					Locale:   "en",
+					FcmToken: fcmToken,
+				},
+				{
+					UserID: uuid.NewV4().String(),
+					Token:  strings.Replace(uuid.NewV4().String(), "-", "", -1),
+					Locale: "en",
+				},
+			}
+
+			compressedUsers, err := worker.CompressUsers(&routingUsers)
+			Expect(err).NotTo(HaveOccurred())
+			msgB, err := json.Marshal(map[string][]interface{}{
+				"args": []interface{}{apnsJob.ID, appName, compressedUsers},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			message, err := goworkers2.NewMsg(string(msgB))
+			Expect(err).NotTo(HaveOccurred())
+
+			processBatchWorker.Process(message)
+
+			Expect(mockKafkaProducer.GCMMessages).To(HaveLen(1))
+			Expect(mockKafkaProducer.APNSMessages).To(HaveLen(1))
+
+			var gcmMessage messages.GCMMessage
+			err = json.Unmarshal([]byte(mockKafkaProducer.GCMMessages[0]), &gcmMessage)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gcmMessage.To).To(Equal(fcmToken))
+			Expect(mockKafkaProducer.GCMTopics[0]).To(Equal(fmt.Sprintf("%s-ios-c", appName)))
+
+			var apnsMessage messages.APNSMessage
+			err = json.Unmarshal([]byte(mockKafkaProducer.APNSMessages[0]), &apnsMessage)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apnsMessage.DeviceToken).To(Equal(routingUsers[1].Token))
+			Expect(mockKafkaProducer.APNSTopics[0]).To(Equal(fmt.Sprintf("%s-apns-c", appName)))
+		})
+
 		It("should choose a random template and put it in push metadata when many are passed to the job", func() {
 			appName := strings.Split(app.BundleID, ".")[2]
 

--- a/worker/process_batch_worker_test.go
+++ b/worker/process_batch_worker_test.go
@@ -252,14 +252,21 @@ var _ = Describe("ProcessBatch Worker", func() {
 
 			processBatchWorker.Process(message)
 
-			Expect(mockKafkaProducer.GCMMessages).To(HaveLen(1))
+			// The fcm_token device routes through the FCM wire shape (not gcm) to
+			// the _ios topic; the other device falls back to APNs.
+			Expect(mockKafkaProducer.FCMMessages).To(HaveLen(1))
 			Expect(mockKafkaProducer.APNSMessages).To(HaveLen(1))
+			Expect(mockKafkaProducer.GCMMessages).To(HaveLen(0))
 
-			var gcmMessage messages.GCMMessage
-			err = json.Unmarshal([]byte(mockKafkaProducer.GCMMessages[0]), &gcmMessage)
+			var fcmMessage messages.FCMMessage
+			err = json.Unmarshal([]byte(mockKafkaProducer.FCMMessages[0]), &fcmMessage)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(gcmMessage.To).To(Equal(fcmToken))
-			Expect(mockKafkaProducer.GCMTopics[0]).To(Equal(fmt.Sprintf("%s-ios-c", appName)))
+			Expect(fcmMessage.To).To(Equal(fcmToken))
+			// The crux of the fix: the rendered alert must reach pusher as a
+			// TOP-LEVEL notification, so buildIOSMessage produces a visible aps.alert.
+			Expect(fcmMessage.Notification).NotTo(BeNil())
+			Expect(fcmMessage.Notification.Body).To(Equal("Everyone just liked your village!"))
+			Expect(mockKafkaProducer.FCMTopics[0]).To(Equal(fmt.Sprintf("%s-ios-c", appName)))
 
 			var apnsMessage messages.APNSMessage
 			err = json.Unmarshal([]byte(mockKafkaProducer.APNSMessages[0]), &apnsMessage)

--- a/worker/process_batch_worker_test.go
+++ b/worker/process_batch_worker_test.go
@@ -268,6 +268,73 @@ var _ = Describe("ProcessBatch Worker", func() {
 			Expect(mockKafkaProducer.APNSTopics[0]).To(Equal(fmt.Sprintf("%s-apns-c", appName)))
 		})
 
+		It("emits the routed_process_batch_worker metric tagged with the resolved provider per device", func() {
+			appName := strings.Split(app.BundleID, ".")[2]
+			apnsJob := CreateTestJob(w.MarathonDB, app.ID, template.Name, map[string]interface{}{
+				"context": context,
+				"service": "apns",
+			})
+
+			routingUsers := []worker.User{
+				{
+					UserID:   uuid.NewV4().String(),
+					Token:    strings.Replace(uuid.NewV4().String(), "-", "", -1),
+					Locale:   "en",
+					FcmToken: "fcm-" + strings.Replace(uuid.NewV4().String(), "-", "", -1),
+				},
+				{
+					UserID: uuid.NewV4().String(),
+					Token:  strings.Replace(uuid.NewV4().String(), "-", "", -1),
+					Locale: "en",
+				},
+			}
+
+			compressedUsers, err := worker.CompressUsers(&routingUsers)
+			Expect(err).NotTo(HaveOccurred())
+			msgB, err := json.Marshal(map[string][]interface{}{
+				"args": []interface{}{apnsJob.ID, appName, compressedUsers},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			message, err := goworkers2.NewMsg(string(msgB))
+			Expect(err).NotTo(HaveOccurred())
+
+			lines := captureStatsd(w, func() {
+				processBatchWorker.Process(message)
+			})
+
+			fcmMetric := fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:fcm", appName)
+			apnsMetric := fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:apns", appName)
+
+			// Exactly one device routed via FCM, exactly one via APNs, and never gcm
+			// on an apns-service job.
+			Expect(countMetric(lines, fcmMetric)).To(Equal(1))
+			Expect(countMetric(lines, apnsMetric)).To(Equal(1))
+			Expect(countMetric(lines, fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:gcm", appName))).To(Equal(0))
+		})
+
+		It("tags the routed metric with provider:gcm for gcm-service jobs", func() {
+			appName := strings.Split(app.BundleID, ".")[2]
+
+			compressedUsers, err := worker.CompressUsers(&users)
+			Expect(err).NotTo(HaveOccurred())
+			msgB, err := json.Marshal(map[string][]interface{}{
+				"args": []interface{}{gcmJob.ID, appName, compressedUsers},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			message, err := goworkers2.NewMsg(string(msgB))
+			Expect(err).NotTo(HaveOccurred())
+
+			lines := captureStatsd(w, func() {
+				processBatchWorker.Process(message)
+			})
+
+			gcmMetric := fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:gcm", appName)
+			Expect(countMetric(lines, gcmMetric)).To(Equal(len(users)))
+			// A gcm job never produces fcm/apns provider tags.
+			Expect(countMetric(lines, fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:fcm", appName))).To(Equal(0))
+			Expect(countMetric(lines, fmt.Sprintf("marathon.routed_process_batch_worker:1|c|#game:%s,provider:apns", appName))).To(Equal(0))
+		})
+
 		It("should choose a random template and put it in push metadata when many are passed to the job", func() {
 			appName := strings.Split(app.BundleID, ".")[2]
 

--- a/worker/statsd_capture_test.go
+++ b/worker/statsd_capture_test.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016 TFG Co <backend@tfgco.com>
+ *
+ * Test helper: captures the raw statsd datagrams a worker emits so tests can
+ * assert the exact metric name, value, type and tags that reach the wire.
+ */
+
+package worker_test
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/marathon/worker"
+)
+
+// captureStatsd points the worker's statsd client at an ephemeral local UDP
+// socket, runs fn, and returns every datagram line that was emitted. It mirrors
+// production config by setting Namespace = "marathon." so assertions can match
+// the fully-qualified metric name. The worker's original client is restored.
+func captureStatsd(w *worker.Worker, fn func()) []string {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+	defer pc.Close()
+
+	client, err := statsd.New(pc.LocalAddr().String())
+	Expect(err).NotTo(HaveOccurred())
+	client.Namespace = "marathon."
+
+	orig := w.Statsd
+	w.Statsd = client
+	defer func() { w.Statsd = orig }()
+
+	var (
+		mu    sync.Mutex
+		lines []string
+		done  = make(chan struct{})
+		exit  = make(chan struct{})
+	)
+	go func() {
+		defer close(exit)
+		buf := make([]byte, 8192)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			pc.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+			n, _, rerr := pc.ReadFrom(buf)
+			if n > 0 {
+				mu.Lock()
+				for _, l := range strings.Split(strings.TrimSpace(string(buf[:n])), "\n") {
+					if l != "" {
+						lines = append(lines, l)
+					}
+				}
+				mu.Unlock()
+			}
+			if rerr != nil {
+				continue // read deadline exceeded; loop and re-check done
+			}
+		}
+	}()
+
+	fn()
+	// Incr sends synchronously over UDP (non-buffered client), but give the
+	// reader a moment to drain the socket buffer before stopping it.
+	time.Sleep(250 * time.Millisecond)
+	close(done)
+	<-exit
+
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]string, len(lines))
+	copy(out, lines)
+	return out
+}
+
+// countMetric returns how many captured lines exactly equal want.
+func countMetric(lines []string, want string) int {
+	n := 0
+	for _, l := range lines {
+		if l == want {
+			n++
+		}
+	}
+	return n
+}

--- a/worker/util.go
+++ b/worker/util.go
@@ -53,6 +53,9 @@ type User struct {
 	Locale string `json:"locale,omitempty" pg:"locale"`
 	Region string `json:"region,omitempty" pg:"region"`
 	Tz     string `json:"tz,omitempty" pg:"tz"`
+	// FcmToken is the FCM address derived from the APNs token; only present on
+	// migrated <game>_apns tables. Empty -> dispatch falls back to APNs.
+	FcmToken string `json:"fcm_token,omitempty" pg:"fcm_token"`
 	// CreatedAt pg.NullTime `json:"created_at,omitempty" sql:"created_at"`
 	// Fiu       string      `json:"fiu,omitempty" sql:"fiu"`
 	// Adid      string      `json:"adid,omitempty" sql:"adid"`
@@ -191,8 +194,9 @@ type BatchWorkerMessage struct {
 func cleanUpUserInfo(user *User) *User {
 	return &User{
 		// UserID: user.UserID,
-		Token:  user.Token,
-		Locale: user.Locale,
+		Token:    user.Token,
+		Locale:   user.Locale,
+		FcmToken: user.FcmToken,
 	}
 }
 


### PR DESCRIPTION
## What

  Adds **FCM-first routing** for iOS dispatch. On an `apns`-service job, a device that
  carries an `fcm_token` is dispatched through **FCM to the `_ios` topic**; every other
  device continues to go out over **APNs**. Token presence is the only switch — APNs is
  the structural fallback, so there is **no per-game flag** to flip.

  This is the marathon dispatch side of the ongoing APNs → FCM migration: once a
  `<game>_apns` table has been backfilled with `fcm_token`s, those users automatically
  start receiving their iOS pushes through FCM with no further config.

  ## Why the FCM wire shape (and not gcm)

  pusher's firebase consumer builds the APNs `aps.alert` **only** from a top-level
  `notification` block — it ignores `data`. The Android `gcm` path puts the whole
  template under `data`, so reusing it on the `_ios` topic would produce an empty `aps`
  (a **silent push**). This PR introduces a dedicated `FCMMessage` that carries the
  rendered alert in the top-level `notification` block, so pusher's `buildIOSMessage`
  produces a non-empty `aps.alert` and iOS renders a visible banner.

  ## Changes

  - **`messages/fcm.go`** (new) — `FCMMessage` + `NewFCMMessage`, which maps an
    APNs-shaped payload onto pusher's firebase shape:
    - `sound` string, and critical-alert sound dict (`{critical, name, volume}`) → `name`
    - `badge`, `content-available` (top-level)
    - `templateName` + message metadata (`m`) carried in `data` for parity with gcm
    - `push_expiry` converted **seconds → milliseconds** (pusher compares against
      `MakeTimestamp()`); `0` means no expiry and is omitted
  - **`interfaces/push_producer.go` / `extensions/kafka_producer.go`** — new
    `SendFCMPush`, including `dryRun` handling (fake token + `dry_run`).
  - **`worker/process_batch_worker.go`** — routing: `apns` + non-empty `fcm_token`
    → `fcm` service on the `_ios` topic; otherwise unchanged. Adds a `fcm` case to
    `sendToKafka`.
  - **`worker/create_batches_worker.go` / `worker/util.go`** — `getUserBatchFromPG`
    probes (process-lifetime cache) whether the push table has the `fcm_token` column
    and selects it only when present; `User` gains `FcmToken`. `fcm_token` only exists
    on migrated `<game>_apns` tables, so selecting it unconditionally would error.
  - **`worker/metrics.go`** — new `routed_process_batch_worker` counter tagged
    `game` + `provider` (apns/fcm/gcm); per-game iOS migration progress =
    `fcm / (fcm + apns)`.

  ## Rollout notes

  - The `fcm_token` column probe is **cached for the process lifetime** (mirrors
    push-api's AR column cache). A game migrated while marathon is running is **not
    picked up until a restart** — restart-after-migration is part of the per-game
    rollout.
  - `NULL` / empty `fcm_token` decodes to `""` → APNs fallback, so partially-migrated
    tables are safe.

  ## Tests

  - `messages/fcm_test.go` — payload mapping, sound/badge/content-available, loc keys,
    the seconds→ms `push_expiry` seam, and that the alert serializes as a **top-level
    `notification`** (not under `data`).
  - `worker/create_batches_fcm_probe_internal_test.go` — column probe (present /
    absent / missing table), the cache behavior, and `getUserBatchFromPG` populating
    `FcmToken`.
  - `worker/process_batch_worker_test.go` — end-to-end routing (fcm_token → FCM/`_ios`,
    others → APNs, never gcm on apns jobs) and the `routed_process_batch_worker` metric
    tags.
  - `worker/statsd_capture_test.go` (new) — helper that captures raw statsd datagrams
    to assert exact metric name/value/tags.